### PR TITLE
Separate application.log and database.log

### DIFF
--- a/htdocs/export/backup_lib.php
+++ b/htdocs/export/backup_lib.php
@@ -326,6 +326,7 @@ class BackupLib
         self::dumpLog("../../local/UILog_2-2.csv", "$backup_dir/UILog_2-2.csv", $server_public_key);
         self::dumpLog("../../local/UILog_2-3.csv", "$backup_dir/UILog_2-3.csv", $server_public_key);
         self::dumpLog("../../log/application.log", "$backup_dir/application.log", $server_public_key);
+        self::dumpLog("../../log/database.log", "$backup_dir/database.log", $server_public_key);
         self::dumpLog("../../log/apache2_error.log", "$backup_dir/apache2_error.log", $server_public_key);
         self::dumpLog("../../log/php_error.log", "$backup_dir/apache2_error.log", $server_public_key);
 

--- a/htdocs/includes/composer.php
+++ b/htdocs/includes/composer.php
@@ -16,6 +16,9 @@ if (!file_exists(__DIR__."/../../log")) {
 $log = new Logger('application');
 $log->pushHandler(new StreamHandler(dirname(__FILE__).'/../../log/application.log', Logger::DEBUG));
 
+$db_log = new Logger('database');
+$db_log->pushHandler(new StreamHandler(dirname(__FILE__).'/../../log/database.log', Logger::DEBUG));
+
 # Check for other folders needed by application
 if (!file_exists(__DIR__."/../../files")) {
     # If not, create it

--- a/htdocs/includes/debug_lib.php
+++ b/htdocs/includes/debug_lib.php
@@ -59,7 +59,7 @@ class DebugLib
 
 	public static function logQuery($query_string, $db_name, $username)
 	{
-        global $log;
+        global $db_log;
 
 		# Adds current query to log
         date_default_timezone_set("UTC");
@@ -72,7 +72,7 @@ class DebugLib
 		$timestamp = date("Y-m-d H:i:s");
 		$log_line = $timestamp."\t".$username."\t".$db_name."\t".$query_string."\n";
 
-        $log->debug("[query] [$db_name] [$username] $query_string");
+        $db_log->debug("[database: $db_name] [application user: $username] $query_string");
 
 		fwrite($file_handle, $log_line);
 		fclose($file_handle);


### PR DESCRIPTION
This will separate out the database queries from the main log, making things easier to debug since the database log is quite noisy.

Similar logs are already made in the `local/langdata_*/` folders - this is old behavior that is preserved. The new logs use a logging library and work like most loggers you'd find in other languages.