### PR TITLE
Infer lab_config_id from session on specimen_type_edit.php

### DIFF
--- a/htdocs/catalog/specimen_type_edit.php
+++ b/htdocs/catalog/specimen_type_edit.php
@@ -9,7 +9,9 @@ LangUtil::setPageId("catalog");
 
 $script_elems->enableJQueryForm();
 $script_elems->enableTokenInput();
-$specimen_type = get_specimen_type_by_id($_REQUEST['sid']);
+
+$lab_config_id = $_SESSION['lab_config_id'];
+$specimen_type = get_specimen_type_by_id($_REQUEST['sid'], $lab_config_id);
 ?>
 <script type='text/javascript'>
 $(document).ready(function(){
@@ -19,7 +21,7 @@ $(document).ready(function(){
 	{
 		# Mark existing compatible tests as checked
 		?>
-		$('#t_type_<?php echo $test_type_id; ?>').attr("checked", "checked"); 
+		$('#t_type_<?php echo $test_type_id; ?>').attr("checked", "checked");
 		<?php
 	}
 	?>
@@ -27,7 +29,7 @@ $(document).ready(function(){
 
 function update_stype()
 {
-	var old_specimen_name = "<?php echo $specimen_type->getName(); ?>";	
+	var old_specimen_name = "<?php echo $specimen_type->getName(); ?>";
 	old_specimen_name = old_specimen_name.toLowerCase();
 	if($('#name').attr("value").trim() == "")
 	{
@@ -51,19 +53,19 @@ function update_stype()
 		//return;
 	}
 	var name_valid=true;
-	var specimen_name = $('#name').attr("value").toLowerCase();	
+	var specimen_name = $('#name').attr("value").toLowerCase();
 	if( specimen_name != old_specimen_name)
 	{
 		var check_url = "ajax/specimen_name_check.php?specimen_name="+specimen_name;
-		$.ajax({ url: check_url, async : false, success: function(response){			
-				if(response == "1")		
-				{	
+		$.ajax({ url: check_url, async : false, success: function(response){
+				if(response == "1")
+				{
 					alert("Spacemen :"+specimen_name + " already exist");
-					name_valid=false;								
-				}			
+					name_valid=false;
+				}
 		}
 		});
-	}	
+	}
 	if(name_valid)
 	{
 		$('#update_stype_progress').show();

--- a/htdocs/includes/db_lib.php
+++ b/htdocs/includes/db_lib.php
@@ -9552,10 +9552,16 @@ function get_test_type_by_id($test_type_id)
 	return TestType::getById($test_type_id);
 }
 
-function get_specimen_type_by_id($specimen_type_id)
+function get_specimen_type_by_id($specimen_type_id, $lab_config_id=null)
 {
 	global $con;
 	$specimen_type_id = mysql_real_escape_string($specimen_type_id, $con);
+
+	# Get current lab ID
+	if ($lab_config_id == null) {
+		$lab_config_id = $_SESSION['lab_config_id'];
+	}
+
 	# Returns specimen type record in DB
 	$saved_db = DbUtil::switchToLabConfigRevamp();
 	$query_string =

--- a/htdocs/includes/db_util.php
+++ b/htdocs/includes/db_util.php
@@ -61,10 +61,13 @@ class DbUtil
 
     public static function switchToLabConfigRevamp($lab_config_id=null)
     {
+        global $log;
+
         $saved_db_name = db_get_current();
         $lab_config = get_lab_config_by_id($lab_config_id);
         if ($lab_config == null) {
             # Error: Lab configuration correspinding to $lab_config_id not found in DB
+            $log->error("Lab configuration corresponding to '$lab_config_id' not found in database");
             return;
         }
         $db_name = $lab_config->dbName;


### PR DESCRIPTION
* Works around an issue where `lab_config_id` is null, and we can't switch to the lab database to get specimen types
* Adds a log message that appears if an error condition happens, rather than silently failing
* Adds an optional `$lab_config_id` parameter to `get_specimen_type_by_id` so it can be passed in rather than inferred

It looks like the file encoding or whitespace changed in `specimen_type_edit.php` - please use "hide whitespace" in the PR settings!