### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: repoName
-        run: echo "lowerCase=${REPO_NAME,,}" >> $GITHUB_OUTPUT
+        run: echo "lowerCase=${REPO_NAME,,}" >> "$GITHUB_OUTPUT"
         env:
           REPO_NAME: ${{ github.repository }}
 

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: repoName
-        run: echo "::set-output name=lowerCase::${REPO_NAME,,}"
+        run: echo "lowerCase=${REPO_NAME,,}" >> $GITHUB_OUTPUT
         env:
           REPO_NAME: ${{ github.repository }}
 

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: repoName
-        run: echo "lowerCase=${REPO_NAME,,}" >> $GITHUB_OUTPUT
+        run: echo "lowerCase=${REPO_NAME,,}" >> "$GITHUB_OUTPUT"
         env:
           REPO_NAME: ${{ github.repository }}
 

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: repoName
-        run: echo "::set-output name=lowerCase::${REPO_NAME,,}"
+        run: echo "lowerCase=${REPO_NAME,,}" >> $GITHUB_OUTPUT
         env:
           REPO_NAME: ${{ github.repository }}
 


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


