### PR TITLE
Add debug tooling and improvements to BLIS release script

### DIFF
--- a/bin/build-blis-release.sh
+++ b/bin/build-blis-release.sh
@@ -1,13 +1,30 @@
 #!/bin/bash
 
-DIR="$(dirname "$0")"
-cd "$DIR" || exit
+set -euo pipefail
 
-mkdir ../dist/Build-BLIS
-cd ../dist/Build-BLIS || exit
- 
-curl -L "https://github.com/C4G/BLISRuntime/archive/refs/heads/main.zip" > BLISRuntime.zip &
-curl -L "https://github.com/C4G/BLIS/archive/refs/heads/master.zip" > BLISCode.zip &
+if ! command -v curl >/dev/null; then
+    echo "You must have curl installed to continue."
+    exit 1
+fi
+
+if ! command -v unzip >/dev/null || ! command -v zip >/dev/null; then
+    echo "You must have zip & unzip installed to continue."
+    exit 1
+fi
+
+echo -e "Creating $(pwd)/dist/ and downloading BLIS release files."
+echo "Press Ctrl-C to stop, or any key to continue."
+
+read -rn1
+echo ""
+
+mkdir -p dist/Build-BLIS || exit 1
+cd dist/Build-BLIS || exit 1
+
+echo "Downloading C4G/BLISRuntime..."
+curl --silent -L "https://github.com/C4G/BLISRuntime/archive/refs/heads/main.zip" > BLISRuntime.zip &
+echo "Downloading C4G/BLIS..."
+curl --silent -L "https://github.com/C4G/BLIS/archive/refs/heads/master.zip" > BLISCode.zip &
 
 wait
 
@@ -42,3 +59,6 @@ rm -rf BLIS-Standalone/
 rm -rf BLIS-Upgrade/
 
 mv BLIS-*.zip ../
+
+cd .. || exit 1
+rm -rf Build-BLIS/

--- a/htdocs/.htaccess
+++ b/htdocs/.htaccess
@@ -269,3 +269,6 @@ RewriteRule ^print_page\.php$ bulk_print/print_page.php
 RewriteRule ^report_content\.php$ bulk_print/report_content.php
 RewriteRule ^print_functions\.php$ bulk_print/print_functions.php
 RewriteRule ^report_word_content\.php$ bulk_print/report_word_content.php
+
+## Debug tooling
+RewriteRule ^debug\.php$ debug/debug.php

--- a/htdocs/debug/debug.php
+++ b/htdocs/debug/debug.php
@@ -1,0 +1,52 @@
+<?php
+
+require_once(__DIR__."/util.php");
+
+require_admin_or_401();
+
+require_once(__DIR__."/../includes/header.php");
+
+?>
+
+<style type="text/css">
+    .debug-flash {
+        background-color: lightpink;
+        margin: 0.5rem;
+        padding: 1rem;
+        font-size: large;
+    }
+</style>
+
+<h2>Debug Utilities</h2>
+
+<?php
+    # This is used for rendering ephemeral messages on this page.
+    # To use, set $_SESSION['DEBUG_FLASH'] on another page and then redirect to this one.
+    # See debug_update_language.php for an example.
+    if ($_SESSION['DEBUG_FLASH'] != '') {
+        echo "<div class=\"debug-flash\">".$_SESSION['DEBUG_FLASH']."</div>";
+        $_SESSION['DEBUG_FLASH'] = '';
+    }
+?>
+
+<h3>Available Log Files</h3>
+
+<ul>
+<?php
+    $available_logs = available_log_files();
+    $log_names = array_keys($available_logs);
+    foreach($log_names as $logfile) {
+        echo "<li><a href=\"/debug/logs.php?name=$logfile\">$logfile</a></li>\n";
+    }
+?>
+</ul>
+
+<h3>Language Utilities</h3>
+
+<ul>
+    <li><a href="/debug/debug_update_language.php">Reset/update language files</a></li>
+</ul>
+
+<?php
+
+require_once("includes/footer.php");

--- a/htdocs/debug/debug_update_language.php
+++ b/htdocs/debug/debug_update_language.php
@@ -1,0 +1,16 @@
+<?php
+
+require_once(__DIR__."/util.php");
+
+require_admin_or_401();
+
+try {
+    # This method is defined in db_lib.php.
+    update_language_files();
+    $_SESSION['DEBUG_FLASH'] = "Language files were reset successfully.";
+} catch (Exception $e) {
+    $_SESSION['DEBUG_FLASH'] = "Language files could not be updated: $e";
+}
+
+header("Location: /debug.php");
+exit();

--- a/htdocs/debug/logs.php
+++ b/htdocs/debug/logs.php
@@ -1,25 +1,11 @@
 <?php
 
-require_once("../includes/composer.php");
-require_once("../includes/db_lib.php");
-require_once("../includes/user_lib.php");
+require_once(__DIR__."/util.php");
 
-$current_user_id = $_SESSION['user_id'];
-$current_user = get_user_by_id($current_user_id);
+require_admin_or_401();
 
-$unauthorized = true;
-
-if (is_super_admin($current_user) || is_country_dir($current_user)) {
-    $unauthorized = false;
-}
-
-if ($unauthorized) {
-    header('HTTP/1.1 401 Unauthorized', true, 401);
-    echo "You do not have permission to view this page.";
-    exit;
-}
-
-$LOG_TYPES = array('application', 'php_error', 'apache2_access', 'apache2_error', 'database');
+$log_files = available_log_files();
+$LOG_TYPES = array_keys($log_files);
 $type = $_GET['name'];
 
 if (!in_array($type, $LOG_TYPES, true)) {
@@ -28,8 +14,7 @@ if (!in_array($type, $LOG_TYPES, true)) {
     exit;
 }
 
-$filename = "$type.log";
 header("Content-Type: text/plain", true, 200);
-header("Content-disposition: attachment;filename=$filename");
+header("Content-disposition: attachment;filename=$type");
 
-readfile(__DIR__."/../../log/".$filename);
+readfile($log_files[$type]);

--- a/htdocs/debug/util.php
+++ b/htdocs/debug/util.php
@@ -1,0 +1,68 @@
+<?
+
+require_once(__DIR__."/../includes/composer.php");
+
+require_once(__DIR__."/../includes/db_lib.php");
+require_once(__DIR__."/../includes/user_lib.php");
+
+function require_admin_or_401() {
+    $current_user_id = $_SESSION['user_id'];
+    $current_user = get_user_by_id($current_user_id);
+
+    $unauthorized = true;
+
+    if (is_super_admin($current_user) || is_country_dir($current_user)) {
+        $unauthorized = false;
+    }
+
+    if ($unauthorized) {
+        header('HTTP/1.1 401 Unauthorized', true, 401);
+        echo "You do not have permission to view this page.";
+        exit;
+    }
+}
+
+function available_log_files() {
+    global $log;
+
+    $log_files = array();
+
+    $application_log = __DIR__."/../../log/application.log";
+    if (file_exists($application_log)) {
+        $log_files["application.log"] = $application_log;
+    }
+
+    $database_log = __DIR__."/../../log/database.log";
+    if (file_exists($database_log)) {
+        $log_files["database.log"] = $database_log;
+    }
+
+    $php_error_log = __DIR__."/../../log/php_error.log";
+    if (file_exists($php_error_log)) {
+        $log_files["php_error.log"] = $php_error_log;
+    }
+
+    $apache2_local_error = __DIR__."/../../log/apache2_error.log";
+    if (file_exists($apache2_local_error)) {
+        $log_files["apache2_error.log"] = $apache2_local_error;
+    }
+
+    $apache2_local_access = __DIR__."/../../log/apache2_access.log";
+    if (file_exists($apache2_local_access)) {
+        $log_files["apache2_access.log"] = $apache2_local_access;
+    }
+
+    $apache2_docker_error = "/var/log/apache2/error.log";
+    $log->error("testing");
+    if (file_exists($apache2_docker_error)) {
+        $log->error("it do exist");
+        $log_files["apache2_var_log_error.log"] = $apache2_docker_error;
+    }
+
+    $apache2_docker_access = "/var/log/apache2/access.log";
+    if (file_exists($apache2_docker_access)) {
+        $log_files["apache2_var_log_access.log"] = $apache2_docker_access;
+    }
+
+    return $log_files;
+}


### PR DESCRIPTION
## Debug Tooling

By visiting `/debug.php` as either a Country Director or a Super Admin, you can see a screen that will let you download the available log files and reset the language settings.

![image](https://github.com/C4G/BLIS/assets/297507/47feda4d-bc9a-4737-a533-702e6b037d3d)

## `build-blis-release.sh`

`build-blis-release.sh` can now run as a standalone script without implying that it depends on the repository contents. This means you can now run it by downloading it directly, eg.

```bash
$ curl https://raw.githubusercontent.com/C4G/BLIS/master/bin/build-blis-release.sh | bash
```