### PR TITLE
Refresh `local/langdata_` folders on login when they don't exist

### DIFF
--- a/htdocs/Language/default.xml
+++ b/htdocs/Language/default.xml
@@ -871,11 +871,11 @@
         </term>
         <term>
             <key>SPECIMEN_CUSTOM_FIELDS</key>
-            <value>Specimen Custom Fields</key>
+            <value>Specimen Custom Fields</value>
         </term>
         <term>
             <key>PATIENT_CUSTOM_FIELDS</key>
-            <value>Patient Custom Fields</key>
+            <value>Patient Custom Fields</value>
         </term>
     </page>
     <page id="header" descr="Page Header">

--- a/htdocs/Language/en.xml
+++ b/htdocs/Language/en.xml
@@ -871,11 +871,11 @@
         </term>
         <term>
             <key>SPECIMEN_CUSTOM_FIELDS</key>
-            <value>Specimen Custom Fields</key>
+            <value>Specimen Custom Fields</value>
         </term>
         <term>
             <key>PATIENT_CUSTOM_FIELDS</key>
-            <value>Patient Custom Fields</key>
+            <value>Patient Custom Fields</value>
         </term>
     </page>
     <page id="header" descr="Page Header">

--- a/htdocs/includes/composer.php
+++ b/htdocs/includes/composer.php
@@ -25,4 +25,27 @@ if (!file_exists(__DIR__."/../../files")) {
     mkdir(__DIR__."/../../files", 0755);
 }
 
+require_once(__DIR__."/platform_lib.php");
+
+# Ensure that we create the language files in local/
+# if they don't exist yet.
+
+$lab_config_id = null;
+if (isset($_SESSION["lab_config_id"])) {
+    $lab_config_id = $_SESSION["lab_config_id"];
+}
+
+$lang_template_path = realpath(__DIR__."/../Language/");
+$local_path = realpath(__DIR__."/../../local");
+
+if (!file_exists("$local_path/langdata_revamp/")) {
+    $log->warn("$local_path/langdata_revamp does not exist, copying template");
+    PlatformLib::copyDirectory($lang_template_path, "$local_path/langdata_revamp/");
+}
+
+if ($lab_config_id != null && !file_exists("$local_path/langdata_$lab_config_id/")) {
+    $log->warn("$local_path/langdata_$lab_config_id does not exist, copying template");
+    PlatformLib::copyDirectory($lang_template_path, "$local_path/langdata_$lab_config_id/");
+}
+
 ?>

--- a/htdocs/users/login.php
+++ b/htdocs/users/login.php
@@ -1,5 +1,5 @@
 <?php
-require_once(__DIR__."/includes/composer.php");
+require_once(__DIR__."/../includes/composer.php");
 include("redirect.php");
 include("includes/stats_lib.php");
 include("includes/password_reset_need.php");

--- a/htdocs/users/login.php
+++ b/htdocs/users/login.php
@@ -1,5 +1,5 @@
 <?php
-
+require_once(__DIR__."/includes/composer.php");
 include("redirect.php");
 include("includes/stats_lib.php");
 include("includes/password_reset_need.php");


### PR DESCRIPTION
It's definitely a hack right now, but sometimes labs are created or imported, and the required language folder in `local/` doesn't get copied in. For example, a lab with ID `123` might not have a `local/langdata_123` folder, and this could screw a number of things up both subtly and un-subtly, including completely breaking BLIS.

Additionally, since up until recently the `local/` folder has been mounted in ephemeral storage in the Docker version of BLIS (my bad!), if a lab was imported with a new ID, its langdata folder would be deleted whenever BLIS is restarted/upgraded. Not good!

Rather than have that happen, I did two things:

1. shoved some code in `composer.php` to copy the template folder into `local/` if (and only if) a lab doesn't doesn't have one already. `composer.php` is included in a bunch of places, but hopefully this expensive operation is only called once, on login, if the folder does not exist.
2. updated `blis-cloud-cli` to create a Docker volume for the `/local` folder. Version `0.2.1`+ should do this automatically.