### PR TITLE
Use monolog for database loggers

### DIFF
--- a/htdocs/includes/composer.php
+++ b/htdocs/includes/composer.php
@@ -5,6 +5,7 @@ require_once(__DIR__."/../../vendor/autoload.php");
 # Logger setup
 
 use Monolog\Logger;
+use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\StreamHandler;
 
 # Check if log/ folder does not exist
@@ -46,6 +47,20 @@ if (!file_exists("$local_path/langdata_revamp/")) {
 if ($lab_config_id != null && !file_exists("$local_path/langdata_$lab_config_id/")) {
     $log->warn("$local_path/langdata_$lab_config_id does not exist, copying template");
     PlatformLib::copyDirectory($lang_template_path, "$local_path/langdata_$lab_config_id/");
+}
+
+$_DATABASE_LOGGERS = array();
+function get_database_logger($dbname) {
+    global $_DATABASE_LOGGERS;
+    if (!isset($_DATABASE_LOGGERS[$dbname])) {
+        $log = new Logger("application");
+        $formatter = new LineFormatter("%message%;\n", "");
+        $stream = new StreamHandler(__DIR__."/../../log/$dbname.sql.log", Logger::DEBUG);
+        $stream->setFormatter($formatter);
+        $log->pushHandler($stream);
+        $_DATABASE_LOGGERS[$dbname] = $log;
+    }
+    return $_DATABASE_LOGGERS[$dbname];
 }
 
 ?>

--- a/htdocs/includes/db_mysql_lib.php
+++ b/htdocs/includes/db_mysql_lib.php
@@ -4,10 +4,9 @@
 # For e.g., use query_associative_all() instead of mysql_query()
 #
 
-require_once("db_constants.php" );
-//include( "db_constants.php" );
-
-require_once(dirname(__FILE__)."/../includes/debug_lib.php");
+require_once(__DIR__."/composer.php");
+require_once(__DIR__."/db_constants.php" );
+require_once(__DIR__."/debug_lib.php");
 
 $con = mysql_connect( $DB_HOST, $DB_USER, $DB_PASS );
 if (!$con) {
@@ -17,19 +16,22 @@ $LOG_QUERIES = true;
 
 mysql_select_db( $DB_NAME, $con );
 
+function _db_get_username() {
+    if (isset($_SESSION['username'])) {
+        return $_SESSION['username'];
+    } else {
+        return "(unset)";
+    }
+}
+
 function query_insert_one($query)
 {
 	# Single insert statement
-	global $con;
+	global $con, $LOG_QUERIES;
     mysql_query( $query, $con ) or die(mysql_error());
-    $LOG_QUERIES = true;
 	if($LOG_QUERIES == true) {
         DebugLib::logDBUpdates($query, db_get_current());
-        $uname = "(unset)";
-        if (isset($_SESSION['username'])) {
-            $uname = $_SESSION['username'];
-        }
-        DebugLib::logQuery($query, db_get_current(), $uname);
+        DebugLib::logQuery($query, db_get_current(), _db_get_username());
     }
 }
 
@@ -37,56 +39,50 @@ function query_insert_one($query)
 function query_update($query)
 {	
 	# Single update statement
-	global $con;
+	global $con, $LOG_QUERIES;
     mysql_query( $query, $con ) or die(mysql_error());
-    $LOG_QUERIES = true;
 	if($LOG_QUERIES == true)	
-        {
-		DebugLib::logQuery($query, db_get_current(), $_SESSION['username']);
+    {
+		DebugLib::logQuery($query, db_get_current(), _db_get_username());
 		DebugLib::logDBUpdates($query, db_get_current());
-        }
+    }
 }
 
 function query_delete($query)
 {
 	# Single delete from statement
-	global $con;
+	global $con, $LOG_QUERIES;
 	mysql_query( $query, $con ) or die(mysql_error());
 	if($LOG_QUERIES == true)
-        {
-		DebugLib::logQuery($query, db_get_current(), $_SESSION['username']);
+    {
+		DebugLib::logQuery($query, db_get_current(), _db_get_username());
 		DebugLib::logDBUpdates($query, db_get_current());
-        }
+    }
 }
 
 function query_alter($query)
 {
 	# Single ALTER statement
-	global $con;
+	global $con, $LOG_QUERIES;
     mysql_query( $query, $con ) or die(mysql_error());
 	if($LOG_QUERIES == true)
-        {
-		DebugLib::logQuery($query, db_get_current(), $_SESSION['username']);
+    {
+		DebugLib::logQuery($query, db_get_current(), _db_get_username());
 		DebugLib::logDBUpdates($query, db_get_current());
-        }
+    }
 }
 
 function query_associative_all($query) 
 {
-    global $con;
+    global $con, $LOG_QUERIES;
 	if( !($result = mysql_query( $query, $con ) ) ) 
 	{
         return null;
     }
     $retval = array();
     while ( $row = mysql_fetch_assoc($result) ){ $retval[] = $row; }
-    $LOG_QUERIES = true;
 	if($LOG_QUERIES == true) {
-        $uname = "(unset)";
-        if (isset($_SESSION['username'])) {
-            $uname = $_SESSION['username'];
-        }
-		DebugLib::logQuery($query, db_get_current(), $uname);
+		DebugLib::logQuery($query, db_get_current(), _db_get_username());
 		DebugLib::logDBUpdates($query, db_get_current());
     }
     return $retval;
@@ -94,110 +90,52 @@ function query_associative_all($query)
 
 function query_associative_one( $query ) 
 {
-    global $con;
+    global $con, $LOG_QUERIES;
 	if( !($result =  mysql_query( $query, $con ) ) ) 
 	{
         return null;
     }
     $retval = mysql_fetch_assoc( $result );
-    $LOG_QUERIES = true;
 	if($LOG_QUERIES == true)
-        {
-		DebugLib::logQuery($query, db_get_current(), $_SESSION['username']);
+    {
+		DebugLib::logQuery($query, db_get_current(), _db_get_username());
 		DebugLib::logDBUpdates($query, db_get_current());
-        }
+    }
 	return $retval;
 }
 
 function query_num_rows( $table_name )
 {
-	global $con;
+	global $con, $LOG_QUERIES;
 	$query_string =
 		"SELECT COUNT(*) AS val FROM $table_name";
 	$record = query_associative_one($query_string);
 	if($LOG_QUERIES == true)
-        {
-		DebugLib::logQuery($query_string, db_get_current(), $_SESSION['username']);
+    {
+		DebugLib::logQuery($query_string, db_get_current(), _db_get_username());
 		DebugLib::logDBUpdates($query, db_get_current());
-        }
+    }
 	return $record['val'];
 }
 
 function query_empty_table( $table_name )
 {
 	# Empty all data in the given table
-	global $con;
-	$query_string =
-		"DELETE FROM $table_name";
+	global $con, $LOG_QUERIES;
+	$query_string = "DELETE FROM $table_name";
 	query_blind($query_string);
 	
 	if($LOG_QUERIES == true)	
-        {
-		DebugLib::logQuery($query_string, db_get_current(), $_SESSION['username']);
+    {
+		DebugLib::logQuery($query_string, db_get_current(), _db_get_username());
 		DebugLib::logDBUpdates($query, db_get_current());
-        }
+    }
 }
 
 function db_escape( $value ) 
 {
     $retval = mysql_real_escape_string( $value );
     return $retval;
-}
-
-function db_prep_positive_real( $value, $zero_ok ) 
-{
-    if( 
-            !isset( $value ) ||
-            (is_null($value)) ||
-            !is_numeric($value) ||
-            ($value == "" )
-      )
-    {
-        $value = 'null';
-    }
-    else 
-	{
-	    if( $value < 0 ) 
-		{
-            $value = 'null';
-        }
-        else if( $value == 0 ) 
-		{
-            if( !$zero_ok ) 
-			{
-                $value = 'null';
-            }
-        }
-    }
-    return (real) $value;
-}
-
-function db_prep_positive_int( $value, $zero_ok ) 
-{
-    if( 
-            !isset( $value ) ||
-            (is_null($value)) ||
-            !is_numeric($value) ||
-            ($value === "" )
-      )
-    {
-        $value = 'null';
-    }
-    else 
-	{
-        if( $value < 0 ) 
-		{
-            $value = 'null';
-        }
-        else if( $value == 0 ) 
-		{
-            if( !$zero_ok ) 
-			{
-                $value = 'null';
-            }
-        }
-    }
-    return $value;
 }
 
 function db_prep_int( $value, $zero_ok ) 
@@ -241,102 +179,55 @@ function db_prep_string( $value )
     return $value;
 }
 
-function db_prep_boolean( $value , $null_allowed = true ) 
-{
-    //error_log('db_bool:'.$value);
-    if( 
-            !isset( $value ) ||
-            (is_null( $value )) ||
-            ($value == "") ||
-            ($value == -1)
-      )
-    {
-        if( $null_allowed ) 
-		{
-            $value = 'null';
-        }
-        else 
-		{
-            $value = 'false';
-        }
-    }
-    else
-    {
-        if(
-                ($value == '1') ||
-                ($value == 't') ||
-                ($value == 'true')
-          )
-        {
-            $value = 'true';
-        }
-        else 
-		{
-            $value = 'false';
-        }
-    }
-    //error_log('db_bool:'.$value);
-    return $value;
-}
-
 function get_last_db_error() 
 {
-    global $con;
+    global $con, $LOG_QUERIES;
     $retval = mysql_error( $con );
     return $retval;
 }
 
 function query_blind( $query ) 
 {
-    global $con;
+    global $con, $LOG_QUERIES;
     $result = mysql_query( $query, $con );
-	$LOG_QUERIES = true;
 	if($LOG_QUERIES == true)
-        {
-		DebugLib::logQuery($query, db_get_current(), $_SESSION['username']);
+    {
+		DebugLib::logQuery($query, db_get_current(), _db_get_username());
 		DebugLib::logDBUpdates($query, db_get_current());
-        }
-    return $result;
-}
-
-function exec_stored_procedure( $query, &$retval ) 
-{
-    global $con;
-    $result = mysql_query( $query, $con );
-    $retval = mysql_fetch_array( $result );
+    }
     return $result;
 }
 
 function get_last_insert_id() 
 {
-    global $con;
+    global $con, $LOG_QUERIES;
     $retval = mysql_insert_id( $con );
     return $retval;
 }
 
 function db_change($db_name) 
 {
-	global $con;
+	global $con, $LOG_QUERIES;
 	mysql_select_db( $db_name, $con );
 }
 
 function db_create($db_name)
 {
-	global $con;
+	global $con, $LOG_QUERIES;
 	$query_string = "CREATE DATABASE $db_name;";
 	mysql_query($query_string, $con);
 }
 
 function db_delete($db_name)
 {
-	global $con;
+	global $con, $LOG_QUERIES;
 	$query_string = "DROP DATABASE ".$db_name;
 	mysql_query($query_string, $con);
 }
 
 function db_get_current()
 {
-	global $con;
+	global $con, $LOG_QUERIES;
 	$query_string = "SELECT DATABASE() AS db_name";
 	$record = mysql_query($query_string, $con);
 	$row = mysql_fetch_assoc($record);
@@ -345,7 +236,7 @@ function db_get_current()
 
 function db_close() 
 {
-	global $con;
+	global $con, $LOG_QUERIES;
 	mysql_close($con);
 }
 

--- a/htdocs/includes/features.php
+++ b/htdocs/includes/features.php
@@ -12,6 +12,10 @@ class Features {
         return Features::ev_enabled("BLIS_LAB_BACKUPS_V2_ENABLED");
     }
 
+    public static function legacy_database_logger() {
+        return Features::ev_enabled("BLIS_LEGACY_DB_LOGGER_ENABLED");
+    }
+
     private static function ev_enabled($ev) {
         return getenv($ev) == "1" || getenv($ev) == "true";
     }


### PR DESCRIPTION
Rather than appending files for each query, database loggers now use Monolog and place their logs in the `log/` directory. This is in line with the other log files and loggers.

Additionally, some unused database functions have been removed, and SELECT statements are not logged in the the database-specific change log, since they don't alter the database. They are still present in `database.log`, however.