### PR TITLE
Add Project Webpage .md doc for P3

### DIFF
--- a/docs/C4G_Spring_2025/20_project_webpage.md
+++ b/docs/C4G_Spring_2025/20_project_webpage.md
@@ -1,0 +1,18 @@
+# Project Webpage
+## Project Description
+Our project will build on C4G's existing BLIS project. C4G Basic Laboratory Information System is a collaboration between Computing for Good (C4G) at Georgia Tech, the Center for Diseaser Control (CDC), and participating PEPFAR countries. The project provides software for tracking of lab test results in developing countries. We will provide support and maintenance, improve existing features, as well as provide new features to the system.
+
+## Overall Project Goal
+Our project will have a few different goals
+- We will improve localization of text for French speakers.
+- We will build a system for satellite labs to seamlessly access results from source labs. 
+- We will fix an existing bug where we can't enroll new clients younger than a year old.
+- We will deploy BLIS-on-cloud to labs.
+
+## Team Members
+- Sofia Muller: Project management and external communications, data engineering for satellite labs feature.
+- Princesca Dorsaint: French localization, data engineering for satellite labs feature, facilitate cloud deployment, externalization.
+- Disha Patel: French localization, UI/UX design, testing.
+- Mishwa Bhavsar: French localization, documentation.
+
+## Lighthouse Scores


### PR DESCRIPTION
- Created new subpage for https://docs.c4gblis.org/ under the C4G Spring 2025 tab to fill the requirements for P3-ProjectWebPage
- Once merged, I will run lighthouse tests on the resulting webpage and add the results.