### PR TITLE
Add $LIS_SATELLITE_LAB_USER type

### DIFF
--- a/htdocs/includes/db_lib.php
+++ b/htdocs/includes/db_lib.php
@@ -26,6 +26,7 @@ $LIS_SUPERADMIN = 3;
 $LIS_COUNTRYDIR = 4;
 $LIS_CLERK = 5;
 $LIS_TECH_SHOWPNAME = 13;
+$LIS_SATELLITE_LAB_USER = 20;
 // New user levels for technicians
 // Regn, Results, Reports
 $LIS_001 = 6;

--- a/htdocs/includes/user_lib.php
+++ b/htdocs/includes/user_lib.php
@@ -241,6 +241,7 @@ function get_top_menu_options($user_role, $user_rwoption = "") {
 	// Called from perms_check.php
 	global $LIS_TECH_RO, $LIS_TECH_RW, $LIS_ADMIN, $LIS_SUPERADMIN, $LIS_VERIFIER, $LIS_COUNTRYDIR, $LIS_CLERK, $READONLYMODE, $LIS_PHYSICIAN;
 	global $LIS_001, $LIS_010, $LIS_011, $LIS_100, $LIS_101, $LIS_110, $LIS_111, $LIS_TECH_SHOWPNAME;
+    global $LIS_SATELLITE_LAB_USER;
 	// Global variables from includes/db_constants.php
 	global $SERVER, $ON_ARC;
 	$page_list = array ();
@@ -263,6 +264,9 @@ function get_top_menu_options($user_role, $user_rwoption = "") {
 		if (in_array ( "7", $rw_option ))
 			$page_list [LangUtil::$pageTerms ['MENU_BACKUP']] = "backupDataUI.php?id=" . $id;
 	}
+    else if ($user_role == $LIS_SATELLITE_LAB_USER) {
+        $page_list ["Get Test Results"] = "test_results.php";
+    }
 	else if ($user_role == $READONLYMODE) {
 		$page_list [LangUtil::getPageTitle ( "reports" )] = "reports.php";
 	}
@@ -304,7 +308,7 @@ function get_top_menu_options($user_role, $user_rwoption = "") {
 		if (in_array ( "7", $rw_option ))
 			$page_list [LangUtil::$pageTerms ['MENU_BACKUP']] = "backupDataUI.php?id=" . $id;
 	}
-	
+
 	return $page_list;
 }
 function rand_str($length = 32, $chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890') {
@@ -354,6 +358,14 @@ function is_country_dir($user) {
 		return true;
 	return false;
 }
+
+function is_satellite_lab_user($user) {
+	global $LIS_SATELLITE_LAB_USER;
+	if ($user->level == $LIS_SATELLITE_LAB_USER)
+		return true;
+	return false;
+}
+
 function get_level_name($level_code) {
 	// Returns string containing user-level
 	global $LIS_PHYSICIAN, $READONLYMODE, $LIS_001, $LIS_TECH_RO, $LIS_TECH_RW, $LIS_ADMIN, $LIS_SUPERADMIN, $LIS_VERIFIER, $LIS_COUNTRYDIR, $LIS_CLERK, $LIS_TECH_SHOWPNAME;


### PR DESCRIPTION
## Hey all!

Here is the code we worked on during the mentor hour tonight (2/24). Below are the notes taken from walking through the codebase that led to this code.

---

UI Notes

Reference Labs
- They manage the computer that is running BLIS
- Satellite labs send them samples to test
- The patients are seen/samples are collected at the satellite labs
- Lab admins create all accounts for satellite labs

Satellite Labs
- They may or may not run BLIS themselves
- They need a way to access test results from the reference lab
- They should not be able to access data from other satellite labs

Patients
- Provide samples to satellite labs
- May go to multiple satellite labs

--------

From Reference Lab BLIS' perspective

- Reference lab admins log in and can see all data in reference lab
- Reference lab technicians log in and can log test results for any satellite lab, and read data for all satellite labs
- Satellite lab users can log in and view test results for their lab

--------

Code exploration notes

- How does the user type system work? How do you check what type a user is?
- How do we determine the different user types?
  - Types are (functionally) hard-coded in db_lib.php
  - Each user row in the database has a "level" column that corresponds to a type
  - Functions like is_country_dir and is_superadmin exist to check the user level against known types
- How do we hide or disable features in the top bar?
