### PR TITLE
Add Localization for the 'Debug Tools' page

### DIFF
--- a/htdocs/Language/default.php
+++ b/htdocs/Language/default.php
@@ -777,7 +777,25 @@ $LANG_ARRAY = array (
 		"CMD_VIEWPROFILE" => "View Profile", 
 		"CMD_DELPROFILE" => "Delete Profile", 
 		"CMD_UPDPROFILE" => "Update Profile"
-	) 
+	) ,
+	"debug" => array (
+		"DEBUG_UTILITIES" => "Debug Utilities",
+		"GIT_COMMIT_SHA" => "Git commit SHA",
+		"BROWSE_SOURCE_CODE" => "browse source code",
+		"AVAILABLE_LOG_FILES" => "Available Log Files",
+		"LANGUAGE_UTILITIES" => "Language Utilities",
+		"RESET_UPDATE_LANGUAGE_FILES" => "Reset/update language files",
+		"DATABASE_UTILITIES" => "Database Utilities",
+		"LEGACY_LAB_DATABASE_MIGRATIONS" => "Legacy Lab Database Migrations",
+		"WARNING" => "Warning!",
+		"MIGRATION_WARNING" => "Running ANY of these migrations could break your lab configuration PERMANENTLY!",
+		"MIGRATION_DESCRIPTION" => "These migrations are used to perform manual updates to an imported lab configuration from an older version of BLIS.",
+		"LAB_DATABASE" => "Lab database",
+		"SELECT_LAB" => "Select a lab",
+		"SQL_MIGRATION" => "SQL migration",
+		"SELECT_MIGRATION" => "Select a migration",
+		"APPLY" => "Apply"
+	)
 );
 
 include_once(__DIR__."/../lang/lang_util.php");

--- a/htdocs/Language/default.xml
+++ b/htdocs/Language/default.xml
@@ -2961,4 +2961,70 @@
             <value>Update Profile</value>
         </term>
     </page>
+    <page id="debug" descr="Debug Utilities">
+        <term>
+            <key>DEBUG_UTILITIES</key>
+            <value>Debug Utilities</value>
+        </term>
+        <term>
+            <key>GIT_COMMIT_SHA</key>
+            <value>Git commit SHA</value>
+        </term>
+        <term>
+            <key>BROWSE_SOURCE_CODE</key>
+            <value>browse source code</value>
+        </term>
+        <term>
+            <key>AVAILABLE_LOG_FILES</key>
+            <value>Available Log Files</value>
+        </term>
+        <term>
+            <key>LANGUAGE_UTILITIES</key>
+            <value>Language Utilities</value>
+        </term>
+        <term>
+            <key>RESET_UPDATE_LANGUAGE_FILES</key>
+            <value>Reset/update language files</value>
+        </term>
+        <term>
+            <key>DATABASE_UTILITIES</key>
+            <value>Database Utilities</value>
+        </term>
+        <term>
+            <key>LEGACY_LAB_DATABASE_MIGRATIONS</key>
+            <value>Legacy Lab Database Migrations</value>
+        </term>
+        <term>
+            <key>WARNING</key>
+            <value>Warning!</value>
+        </term>
+        <term>
+            <key>MIGRATION_WARNING</key>
+            <value>Running ANY of these migrations could break your lab configuration PERMANENTLY!</value>
+        </term>
+        <term>
+            <key>MIGRATION_DESCRIPTION</key>
+            <value>These migrations are used to perform manual updates to an imported lab configuration from an older version of BLIS.</value>
+        </term>
+        <term>
+            <key>LAB_DATABASE</key>
+            <value>Lab database</value>
+        </term>
+        <term>
+            <key>SELECT_LAB</key>
+            <value>Select a lab</value>
+        </term>
+        <term>
+            <key>SQL_MIGRATION</key>
+            <value>SQL migration</value>
+        </term>
+        <term>
+            <key>SELECT_MIGRATION</key>
+            <value>Select a migration</value>
+        </term>
+        <term>
+            <key>APPLY</key>
+            <value>Apply</value>
+        </term>
+    </page>
 </pages>

--- a/htdocs/Language/en.php
+++ b/htdocs/Language/en.php
@@ -777,7 +777,25 @@ $LANG_ARRAY = array (
 		"CMD_VIEWPROFILE" => "View Profile", 
 		"CMD_DELPROFILE" => "Delete Profile", 
 		"CMD_UPDPROFILE" => "Update Profile"
-	) 
+	) ,
+	"debug" => array (
+		"DEBUG_UTILITIES" => "Debug Utilities",
+		"GIT_COMMIT_SHA" => "Git commit SHA",
+		"BROWSE_SOURCE_CODE" => "browse source code",
+		"AVAILABLE_LOG_FILES" => "Available Log Files",
+		"LANGUAGE_UTILITIES" => "Language Utilities",
+		"RESET_UPDATE_LANGUAGE_FILES" => "Reset/update language files",
+		"DATABASE_UTILITIES" => "Database Utilities",
+		"LEGACY_LAB_DATABASE_MIGRATIONS" => "Legacy Lab Database Migrations",
+		"WARNING" => "Warning!",
+		"MIGRATION_WARNING" => "Running ANY of these migrations could break your lab configuration PERMANENTLY!",
+		"MIGRATION_DESCRIPTION" => "These migrations are used to perform manual updates to an imported lab configuration from an older version of BLIS.",
+		"LAB_DATABASE" => "Lab database",
+		"SELECT_LAB" => "Select a lab",
+		"SQL_MIGRATION" => "SQL migration",
+		"SELECT_MIGRATION" => "Select a migration",
+		"APPLY" => "Apply"
+	)
 );
 
 include_once(__DIR__."/../lang/lang_util.php");

--- a/htdocs/Language/en.xml
+++ b/htdocs/Language/en.xml
@@ -2961,4 +2961,70 @@
             <value>Update Profile</value>
         </term>
     </page>
+    <page id="debug" descr="Debug Utilities">
+        <term>
+            <key>DEBUG_UTILITIES</key>
+            <value>Debug Utilities</value>
+        </term>
+        <term>
+            <key>GIT_COMMIT_SHA</key>
+            <value>Git commit SHA</value>
+        </term>
+        <term>
+            <key>BROWSE_SOURCE_CODE</key>
+            <value>browse source code</value>
+        </term>
+        <term>
+            <key>AVAILABLE_LOG_FILES</key>
+            <value>Available Log Files</value>
+        </term>
+        <term>
+            <key>LANGUAGE_UTILITIES</key>
+            <value>Language Utilities</value>
+        </term>
+        <term>
+            <key>RESET_UPDATE_LANGUAGE_FILES</key>
+            <value>Reset/update language files</value>
+        </term>
+        <term>
+            <key>DATABASE_UTILITIES</key>
+            <value>Database Utilities</value>
+        </term>
+        <term>
+            <key>LEGACY_LAB_DATABASE_MIGRATIONS</key>
+            <value>Legacy Lab Database Migrations</value>
+        </term>
+        <term>
+            <key>WARNING</key>
+            <value>Warning!</value>
+        </term>
+        <term>
+            <key>MIGRATION_WARNING</key>
+            <value>Running ANY of these migrations could break your lab configuration PERMANENTLY!</value>
+        </term>
+        <term>
+            <key>MIGRATION_DESCRIPTION</key>
+            <value>These migrations are used to perform manual updates to an imported lab configuration from an older version of BLIS.</value>
+        </term>
+        <term>
+            <key>LAB_DATABASE</key>
+            <value>Lab database</value>
+        </term>
+        <term>
+            <key>SELECT_LAB</key>
+            <value>Select a lab</value>
+        </term>
+        <term>
+            <key>SQL_MIGRATION</key>
+            <value>SQL migration</value>
+        </term>
+        <term>
+            <key>SELECT_MIGRATION</key>
+            <value>Select a migration</value>
+        </term>
+        <term>
+            <key>APPLY</key>
+            <value>Apply</value>
+        </term>
+    </page>
 </pages>

--- a/htdocs/Language/fr.php
+++ b/htdocs/Language/fr.php
@@ -722,7 +722,25 @@ $LANG_ARRAY = array (
 		"SEARCH_BEGIN_WITH" => "Commence par", 
 		"SEARCH_END_WITH" => "Fin d'", 
 		"SEARCH_CONTAINS" => "Contient"
-	) 
+	) ,
+	"debug" => array (
+        "DEBUG_UTILITIES" => "Utilitaires de débogage",
+        "GIT_COMMIT_SHA" => "SHA du commit Git",
+        "BROWSE_SOURCE_CODE" => "parcourir le code source",
+        "AVAILABLE_LOG_FILES" => "Fichiers de journal disponibles",
+        "LANGUAGE_UTILITIES" => "Utilitaires de langue",
+        "RESET_UPDATE_LANGUAGE_FILES" => "Réinitialiser/mettre à jour les fichiers de langue",
+        "DATABASE_UTILITIES" => "Utilitaires de base de données",
+        "LEGACY_LAB_DATABASE_MIGRATIONS" => "Migrations de la base de données du laboratoire hérité",
+        "WARNING" => "Attention!",
+        "MIGRATION_WARNING" => "Exécuter l'une de ces migrations pourrait casser votre configuration de laboratoire DE MANIÈRE PERMANENTE !",
+        "MIGRATION_DESCRIPTION" => "Ces migrations sont utilisées pour effectuer des mises à jour manuelles d'une configuration de laboratoire importée à partir d'une ancienne version de BLIS.",
+        "LAB_DATABASE" => "Base de données du laboratoire",
+        "SELECT_LAB" => "Sélectionnez un laboratoire",
+        "SQL_MIGRATION" => "Migration SQL",
+        "SELECT_MIGRATION" => "Sélectionnez une migration",
+        "APPLY" => "Appliquer"
+    )
 );
 
 include_once(__DIR__."/../lang/lang_util.php");

--- a/htdocs/Language/fr.xml
+++ b/htdocs/Language/fr.xml
@@ -2749,4 +2749,70 @@
 			<value>Contient</value>
 		</term>
  </page>
+	<page id="debug" descr="Debug Utilities">
+        <term>
+            <key>DEBUG_UTILITIES</key>
+            <value>Utilitaires de débogage</value>
+        </term>
+        <term>
+            <key>GIT_COMMIT_SHA</key>
+            <value>SHA du commit Git</value>
+        </term>
+        <term>
+            <key>BROWSE_SOURCE_CODE</key>
+            <value>parcourir le code source</value>
+        </term>
+        <term>
+            <key>AVAILABLE_LOG_FILES</key>
+            <value>Fichiers de journal disponibles</value>
+        </term>
+        <term>
+            <key>LANGUAGE_UTILITIES</key>
+            <value>Utilitaires de langue</value>
+        </term>
+        <term>
+            <key>RESET_UPDATE_LANGUAGE_FILES</key>
+            <value>Réinitialiser/mettre à jour les fichiers de langue</value>
+        </term>
+        <term>
+            <key>DATABASE_UTILITIES</key>
+            <value>Utilitaires de base de données</value>
+        </term>
+        <term>
+            <key>LEGACY_LAB_DATABASE_MIGRATIONS</key>
+            <value>Migrations de la base de données du laboratoire hérité</value>
+        </term>
+        <term>
+            <key>WARNING</key>
+            <value>Attention!</value>
+        </term>
+        <term>
+            <key>MIGRATION_WARNING</key>
+            <value>Exécuter l'une de ces migrations pourrait casser votre configuration de laboratoire DE MANIÈRE PERMANENTE !</value>
+        </term>
+        <term>
+            <key>MIGRATION_DESCRIPTION</key>
+            <value>Ces migrations sont utilisées pour effectuer des mises à jour manuelles d'une configuration de laboratoire importée à partir d'une ancienne version de BLIS.</value>
+        </term>
+        <term>
+            <key>LAB_DATABASE</key>
+            <value>Base de données du laboratoire</value>
+        </term>
+        <term>
+            <key>SELECT_LAB</key>
+            <value>Sélectionnez un laboratoire</value>
+        </term>
+        <term>
+            <key>SQL_MIGRATION</key>
+            <value>Migration SQL</value>
+        </term>
+        <term>
+            <key>SELECT_MIGRATION</key>
+            <value>Sélectionnez une migration</value>
+        </term>
+        <term>
+            <key>APPLY</key>
+            <value>Appliquer</value>
+        </term>
+    </page>
 </pages>

--- a/htdocs/debug/debug.php
+++ b/htdocs/debug/debug.php
@@ -4,6 +4,8 @@ require_once(__DIR__."/util.php");
 
 require_admin_or_401();
 
+LangUtil::setPageId("debug");
+
 require_once(__DIR__."/../includes/header.php");
 
 ?>
@@ -16,7 +18,7 @@ require_once(__DIR__."/../includes/header.php");
     }
 </style>
 
-<h2>Debug Utilities</h2>
+<h2><?php echo LangUtil::$debug['DEBUG_UTILITIES']; ?></h2>
 
 <?php
     $commit_sha = getenv('GIT_COMMIT_SHA');
@@ -29,10 +31,10 @@ require_once(__DIR__."/../includes/header.php");
 ?>
 
 <p>
-    <b>Git commit SHA:</b> <code><?php echo($commit_sha); ?></code> <i>(<a href="<?php echo($github_link); ?>">browse source code</a>)</i>
+    <b><?php echo LangUtil::$debug['GIT_COMMIT_SHA']; ?>:</b> <code><?php echo($commit_sha); ?></code> <i>(<a href="<?php echo($github_link); ?>"><?php echo LangUtil::$debug['BROWSE_SOURCE_CODE']; ?></a>)</i>
 </p>
 
-<h3>Available Log Files</h3>
+<h3><?php echo LangUtil::$debug['AVAILABLE_LOG_FILES']; ?></h3>
 
 <ul>
 <?php
@@ -44,28 +46,26 @@ require_once(__DIR__."/../includes/header.php");
 ?>
 </ul>
 
-<h3>Language Utilities</h3>
+<h3><?php echo LangUtil::$debug['LANGUAGE_UTILITIES']; ?></h3>
 
 <ul>
-    <li><a href="/debug/debug_update_language.php">Reset/update language files</a></li>
+    <li><a href="/debug/debug_update_language.php"><?php echo LangUtil::$debug['RESET_UPDATE_LANGUAGE_FILES']; ?></a></li>
 </ul>
 
-<h3>Database Utilities</h3>
+<h3><?php echo LangUtil::$debug['DATABASE_UTILITIES']; ?></h3>
 
-<h4>Legacy Lab Database Migrations</h4>
+<h4><?php echo LangUtil::$debug['LEGACY_LAB_DATABASE_MIGRATIONS']; ?></h4>
 
 <p>
-    <span class="red-danger">Warning!</span><br/>
-    Running ANY of these migrations could break your lab configuration
-    <span class="red-danger">PERMANENTLY!</span><br/>
-    These migrations are used to perform manual updates to an imported lab configuration
-    from an older version of BLIS.
+    <span class="red-danger"><?php echo LangUtil::$debug['WARNING']; ?></span><br/>
+    <?php echo LangUtil::$debug['MIGRATION_WARNING']; ?><br/>
+    <?php echo LangUtil::$debug['MIGRATION_DESCRIPTION']; ?>
 </p>
 
 <form action="/debug/debug_apply_migration.php" method="GET">
-    <label for="migration-lab-select">Lab database:</label>
+    <label for="migration-lab-select"><?php echo LangUtil::$debug['LAB_DATABASE']; ?>:</label>
     <select id="migration-lab-select" name="lab">
-        <option value="">Select a lab</option>
+        <option value=""><?php echo LangUtil::$debug['SELECT_LAB']; ?></option>
     <?php
         $lab_configs = get_lab_configs();
         foreach($lab_configs as $lab) {
@@ -77,9 +77,9 @@ require_once(__DIR__."/../includes/header.php");
 
     <br/>
 
-    <label for="migration-select">SQL migration:</label>
+    <label for="migration-select"><?php echo LangUtil::$debug['SQL_MIGRATION']; ?>:</label>
     <select id="migration-select" name="migration">
-        <option value="">Select a migration</option>
+        <option value=""><?php echo LangUtil::$debug['SELECT_MIGRATION']; ?></option>
     <?php
         $available_migrations = list_files_like(__DIR__."/../data/", "/db_update_lab/");
         foreach($available_migrations as $migration) {
@@ -90,7 +90,7 @@ require_once(__DIR__."/../includes/header.php");
 
     <br/>
 
-    <input type="submit" value="Apply"/>
+    <input type="submit" value="<?php echo LangUtil::$debug['APPLY']; ?>"/>
 </form>
 
 <?php

--- a/local/langdata_12/default.php
+++ b/local/langdata_12/default.php
@@ -777,7 +777,25 @@ $LANG_ARRAY = array (
 		"CMD_VIEWPROFILE" => "View Profile", 
 		"CMD_DELPROFILE" => "Delete Profile", 
 		"CMD_UPDPROFILE" => "Update Profile"
-	) 
+	) , 
+	"debug" => array (
+		"DEBUG_UTILITIES" => "Debug Utilities",
+		"GIT_COMMIT_SHA" => "Git commit SHA",
+		"BROWSE_SOURCE_CODE" => "browse source code",
+		"AVAILABLE_LOG_FILES" => "Available Log Files",
+		"LANGUAGE_UTILITIES" => "Language Utilities",
+		"RESET_UPDATE_LANGUAGE_FILES" => "Reset/update language files",
+		"DATABASE_UTILITIES" => "Database Utilities",
+		"LEGACY_LAB_DATABASE_MIGRATIONS" => "Legacy Lab Database Migrations",
+		"WARNING" => "Warning!",
+		"MIGRATION_WARNING" => "Running ANY of these migrations could break your lab configuration PERMANENTLY!",
+		"MIGRATION_DESCRIPTION" => "These migrations are used to perform manual updates to an imported lab configuration from an older version of BLIS.",
+		"LAB_DATABASE" => "Lab database",
+		"SELECT_LAB" => "Select a lab",
+		"SQL_MIGRATION" => "SQL migration",
+		"SELECT_MIGRATION" => "Select a migration",
+		"APPLY" => "Apply"
+	)
 );
 
 include_once(__DIR__."/../lang/lang_util.php");

--- a/local/langdata_12/default.xml
+++ b/local/langdata_12/default.xml
@@ -2961,4 +2961,70 @@
             <value>Update Profile</value>
         </term>
     </page>
+    <page id="debug" descr="Debug Utilities">
+        <term>
+            <key>DEBUG_UTILITIES</key>
+            <value>Debug Utilities</value>
+        </term>
+        <term>
+            <key>GIT_COMMIT_SHA</key>
+            <value>Git commit SHA</value>
+        </term>
+        <term>
+            <key>BROWSE_SOURCE_CODE</key>
+            <value>browse source code</value>
+        </term>
+        <term>
+            <key>AVAILABLE_LOG_FILES</key>
+            <value>Available Log Files</value>
+        </term>
+        <term>
+            <key>LANGUAGE_UTILITIES</key>
+            <value>Language Utilities</value>
+        </term>
+        <term>
+            <key>RESET_UPDATE_LANGUAGE_FILES</key>
+            <value>Reset/update language files</value>
+        </term>
+        <term>
+            <key>DATABASE_UTILITIES</key>
+            <value>Database Utilities</value>
+        </term>
+        <term>
+            <key>LEGACY_LAB_DATABASE_MIGRATIONS</key>
+            <value>Legacy Lab Database Migrations</value>
+        </term>
+        <term>
+            <key>WARNING</key>
+            <value>Warning!</value>
+        </term>
+        <term>
+            <key>MIGRATION_WARNING</key>
+            <value>Running ANY of these migrations could break your lab configuration PERMANENTLY!</value>
+        </term>
+        <term>
+            <key>MIGRATION_DESCRIPTION</key>
+            <value>These migrations are used to perform manual updates to an imported lab configuration from an older version of BLIS.</value>
+        </term>
+        <term>
+            <key>LAB_DATABASE</key>
+            <value>Lab database</value>
+        </term>
+        <term>
+            <key>SELECT_LAB</key>
+            <value>Select a lab</value>
+        </term>
+        <term>
+            <key>SQL_MIGRATION</key>
+            <value>SQL migration</value>
+        </term>
+        <term>
+            <key>SELECT_MIGRATION</key>
+            <value>Select a migration</value>
+        </term>
+        <term>
+            <key>APPLY</key>
+            <value>Apply</value>
+        </term>
+    </page>
 </pages>

--- a/local/langdata_12/en.php
+++ b/local/langdata_12/en.php
@@ -777,7 +777,25 @@ $LANG_ARRAY = array (
 		"CMD_VIEWPROFILE" => "View Profile", 
 		"CMD_DELPROFILE" => "Delete Profile", 
 		"CMD_UPDPROFILE" => "Update Profile"
-	) 
+	) ,
+	"debug" => array (
+        "DEBUG_UTILITIES" => "Debug Utilities",
+        "GIT_COMMIT_SHA" => "Git commit SHA",
+        "BROWSE_SOURCE_CODE" => "browse source code",
+        "AVAILABLE_LOG_FILES" => "Available Log Files",
+        "LANGUAGE_UTILITIES" => "Language Utilities",
+        "RESET_UPDATE_LANGUAGE_FILES" => "Reset/update language files",
+        "DATABASE_UTILITIES" => "Database Utilities",
+        "LEGACY_LAB_DATABASE_MIGRATIONS" => "Legacy Lab Database Migrations",
+        "WARNING" => "Warning!",
+        "MIGRATION_WARNING" => "Running ANY of these migrations could break your lab configuration PERMANENTLY!",
+        "MIGRATION_DESCRIPTION" => "These migrations are used to perform manual updates to an imported lab configuration from an older version of BLIS.",
+        "LAB_DATABASE" => "Lab database",
+        "SELECT_LAB" => "Select a lab",
+        "SQL_MIGRATION" => "SQL migration",
+        "SELECT_MIGRATION" => "Select a migration",
+        "APPLY" => "Apply"
+    )
 );
 
 include_once(__DIR__."/../lang/lang_util.php");

--- a/local/langdata_12/en.xml
+++ b/local/langdata_12/en.xml
@@ -2961,4 +2961,70 @@
             <value>Update Profile</value>
         </term>
     </page>
+    <page id="debug" descr="Debug Utilities">
+        <term>
+            <key>DEBUG_UTILITIES</key>
+            <value>Debug Utilities</value>
+        </term>
+        <term>
+            <key>GIT_COMMIT_SHA</key>
+            <value>Git commit SHA</value>
+        </term>
+        <term>
+            <key>BROWSE_SOURCE_CODE</key>
+            <value>browse source code</value>
+        </term>
+        <term>
+            <key>AVAILABLE_LOG_FILES</key>
+            <value>Available Log Files</value>
+        </term>
+        <term>
+            <key>LANGUAGE_UTILITIES</key>
+            <value>Language Utilities</value>
+        </term>
+        <term>
+            <key>RESET_UPDATE_LANGUAGE_FILES</key>
+            <value>Reset/update language files</value>
+        </term>
+        <term>
+            <key>DATABASE_UTILITIES</key>
+            <value>Database Utilities</value>
+        </term>
+        <term>
+            <key>LEGACY_LAB_DATABASE_MIGRATIONS</key>
+            <value>Legacy Lab Database Migrations</value>
+        </term>
+        <term>
+            <key>WARNING</key>
+            <value>Warning!</value>
+        </term>
+        <term>
+            <key>MIGRATION_WARNING</key>
+            <value>Running ANY of these migrations could break your lab configuration PERMANENTLY!</value>
+        </term>
+        <term>
+            <key>MIGRATION_DESCRIPTION</key>
+            <value>These migrations are used to perform manual updates to an imported lab configuration from an older version of BLIS.</value>
+        </term>
+        <term>
+            <key>LAB_DATABASE</key>
+            <value>Lab database</value>
+        </term>
+        <term>
+            <key>SELECT_LAB</key>
+            <value>Select a lab</value>
+        </term>
+        <term>
+            <key>SQL_MIGRATION</key>
+            <value>SQL migration</value>
+        </term>
+        <term>
+            <key>SELECT_MIGRATION</key>
+            <value>Select a migration</value>
+        </term>
+        <term>
+            <key>APPLY</key>
+            <value>Apply</value>
+        </term>
+    </page>
 </pages>

--- a/local/langdata_12/fr.php
+++ b/local/langdata_12/fr.php
@@ -722,7 +722,25 @@ $LANG_ARRAY = array (
 		"SEARCH_BEGIN_WITH" => "Commence par", 
 		"SEARCH_END_WITH" => "Fin d'", 
 		"SEARCH_CONTAINS" => "Contient"
-	) 
+	) ,
+	"debug" => array (
+        "DEBUG_UTILITIES" => "Utilitaires de débogage",
+        "GIT_COMMIT_SHA" => "SHA du commit Git",
+        "BROWSE_SOURCE_CODE" => "parcourir le code source",
+        "AVAILABLE_LOG_FILES" => "Fichiers de journal disponibles",
+        "LANGUAGE_UTILITIES" => "Utilitaires de langue",
+        "RESET_UPDATE_LANGUAGE_FILES" => "Réinitialiser/mettre à jour les fichiers de langue",
+        "DATABASE_UTILITIES" => "Utilitaires de base de données",
+        "LEGACY_LAB_DATABASE_MIGRATIONS" => "Migrations de la base de données du laboratoire hérité",
+        "WARNING" => "Attention!",
+        "MIGRATION_WARNING" => "Exécuter l'une de ces migrations pourrait casser votre configuration de laboratoire DE MANIÈRE PERMANENTE !",
+        "MIGRATION_DESCRIPTION" => "Ces migrations sont utilisées pour effectuer des mises à jour manuelles d'une configuration de laboratoire importée à partir d'une ancienne version de BLIS.",
+        "LAB_DATABASE" => "Base de données du laboratoire",
+        "SELECT_LAB" => "Sélectionnez un laboratoire",
+        "SQL_MIGRATION" => "Migration SQL",
+        "SELECT_MIGRATION" => "Sélectionnez une migration",
+        "APPLY" => "Appliquer"
+    )
 );
 
 include_once(__DIR__."/../lang/lang_util.php");

--- a/local/langdata_12/fr.xml
+++ b/local/langdata_12/fr.xml
@@ -2749,4 +2749,70 @@
 			<value>Contient</value>
 		</term>
  </page>
+ <page id="debug" descr="Debug Utilities">
+        <term>
+            <key>DEBUG_UTILITIES</key>
+            <value>Utilitaires de débogage</value>
+        </term>
+        <term>
+            <key>GIT_COMMIT_SHA</key>
+            <value>SHA du commit Git</value>
+        </term>
+        <term>
+            <key>BROWSE_SOURCE_CODE</key>
+            <value>parcourir le code source</value>
+        </term>
+        <term>
+            <key>AVAILABLE_LOG_FILES</key>
+            <value>Fichiers de journal disponibles</value>
+        </term>
+        <term>
+            <key>LANGUAGE_UTILITIES</key>
+            <value>Utilitaires de langue</value>
+        </term>
+        <term>
+            <key>RESET_UPDATE_LANGUAGE_FILES</key>
+            <value>Réinitialiser/mettre à jour les fichiers de langue</value>
+        </term>
+        <term>
+            <key>DATABASE_UTILITIES</key>
+            <value>Utilitaires de base de données</value>
+        </term>
+        <term>
+            <key>LEGACY_LAB_DATABASE_MIGRATIONS</key>
+            <value>Migrations de la base de données du laboratoire hérité</value>
+        </term>
+        <term>
+            <key>WARNING</key>
+            <value>Attention!</value>
+        </term>
+        <term>
+            <key>MIGRATION_WARNING</key>
+            <value>Exécuter l'une de ces migrations pourrait casser votre configuration de laboratoire DE MANIÈRE PERMANENTE !</value>
+        </term>
+        <term>
+            <key>MIGRATION_DESCRIPTION</key>
+            <value>Ces migrations sont utilisées pour effectuer des mises à jour manuelles d'une configuration de laboratoire importée à partir d'une ancienne version de BLIS.</value>
+        </term>
+        <term>
+            <key>LAB_DATABASE</key>
+            <value>Base de données du laboratoire</value>
+        </term>
+        <term>
+            <key>SELECT_LAB</key>
+            <value>Sélectionnez un laboratoire</value>
+        </term>
+        <term>
+            <key>SQL_MIGRATION</key>
+            <value>Migration SQL</value>
+        </term>
+        <term>
+            <key>SELECT_MIGRATION</key>
+            <value>Sélectionnez une migration</value>
+        </term>
+        <term>
+            <key>APPLY</key>
+            <value>Appliquer</value>
+        </term>
+    </page>
 </pages>

--- a/local/langdata_127/default.php
+++ b/local/langdata_127/default.php
@@ -777,7 +777,25 @@ $LANG_ARRAY = array (
 		"CMD_VIEWPROFILE" => "View Profile", 
 		"CMD_DELPROFILE" => "Delete Profile", 
 		"CMD_UPDPROFILE" => "Update Profile"
-	) 
+	) ,
+	"debug" => array (
+		"DEBUG_UTILITIES" => "Debug Utilities",
+		"GIT_COMMIT_SHA" => "Git commit SHA",
+		"BROWSE_SOURCE_CODE" => "browse source code",
+		"AVAILABLE_LOG_FILES" => "Available Log Files",
+		"LANGUAGE_UTILITIES" => "Language Utilities",
+		"RESET_UPDATE_LANGUAGE_FILES" => "Reset/update language files",
+		"DATABASE_UTILITIES" => "Database Utilities",
+		"LEGACY_LAB_DATABASE_MIGRATIONS" => "Legacy Lab Database Migrations",
+		"WARNING" => "Warning!",
+		"MIGRATION_WARNING" => "Running ANY of these migrations could break your lab configuration PERMANENTLY!",
+		"MIGRATION_DESCRIPTION" => "These migrations are used to perform manual updates to an imported lab configuration from an older version of BLIS.",
+		"LAB_DATABASE" => "Lab database",
+		"SELECT_LAB" => "Select a lab",
+		"SQL_MIGRATION" => "SQL migration",
+		"SELECT_MIGRATION" => "Select a migration",
+		"APPLY" => "Apply"
+	)
 );
 
 include_once(__DIR__."/../lang/lang_util.php");

--- a/local/langdata_127/default.xml
+++ b/local/langdata_127/default.xml
@@ -2961,4 +2961,70 @@
             <value>Update Profile</value>
         </term>
     </page>
+    <page id="debug" descr="Debug Utilities">
+        <term>
+            <key>DEBUG_UTILITIES</key>
+            <value>Debug Utilities</value>
+        </term>
+        <term>
+            <key>GIT_COMMIT_SHA</key>
+            <value>Git commit SHA</value>
+        </term>
+        <term>
+            <key>BROWSE_SOURCE_CODE</key>
+            <value>browse source code</value>
+        </term>
+        <term>
+            <key>AVAILABLE_LOG_FILES</key>
+            <value>Available Log Files</value>
+        </term>
+        <term>
+            <key>LANGUAGE_UTILITIES</key>
+            <value>Language Utilities</value>
+        </term>
+        <term>
+            <key>RESET_UPDATE_LANGUAGE_FILES</key>
+            <value>Reset/update language files</value>
+        </term>
+        <term>
+            <key>DATABASE_UTILITIES</key>
+            <value>Database Utilities</value>
+        </term>
+        <term>
+            <key>LEGACY_LAB_DATABASE_MIGRATIONS</key>
+            <value>Legacy Lab Database Migrations</value>
+        </term>
+        <term>
+            <key>WARNING</key>
+            <value>Warning!</value>
+        </term>
+        <term>
+            <key>MIGRATION_WARNING</key>
+            <value>Running ANY of these migrations could break your lab configuration PERMANENTLY!</value>
+        </term>
+        <term>
+            <key>MIGRATION_DESCRIPTION</key>
+            <value>These migrations are used to perform manual updates to an imported lab configuration from an older version of BLIS.</value>
+        </term>
+        <term>
+            <key>LAB_DATABASE</key>
+            <value>Lab database</value>
+        </term>
+        <term>
+            <key>SELECT_LAB</key>
+            <value>Select a lab</value>
+        </term>
+        <term>
+            <key>SQL_MIGRATION</key>
+            <value>SQL migration</value>
+        </term>
+        <term>
+            <key>SELECT_MIGRATION</key>
+            <value>Select a migration</value>
+        </term>
+        <term>
+            <key>APPLY</key>
+            <value>Apply</value>
+        </term>
+    </page>
 </pages>

--- a/local/langdata_127/en.php
+++ b/local/langdata_127/en.php
@@ -777,7 +777,25 @@ $LANG_ARRAY = array (
 		"CMD_VIEWPROFILE" => "View Profile", 
 		"CMD_DELPROFILE" => "Delete Profile", 
 		"CMD_UPDPROFILE" => "Update Profile"
-	) 
+	) ,
+	"debug" => array (
+        "DEBUG_UTILITIES" => "Debug Utilities",
+        "GIT_COMMIT_SHA" => "Git commit SHA",
+        "BROWSE_SOURCE_CODE" => "browse source code",
+        "AVAILABLE_LOG_FILES" => "Available Log Files",
+        "LANGUAGE_UTILITIES" => "Language Utilities",
+        "RESET_UPDATE_LANGUAGE_FILES" => "Reset/update language files",
+        "DATABASE_UTILITIES" => "Database Utilities",
+        "LEGACY_LAB_DATABASE_MIGRATIONS" => "Legacy Lab Database Migrations",
+        "WARNING" => "Warning!",
+        "MIGRATION_WARNING" => "Running ANY of these migrations could break your lab configuration PERMANENTLY!",
+        "MIGRATION_DESCRIPTION" => "These migrations are used to perform manual updates to an imported lab configuration from an older version of BLIS.",
+        "LAB_DATABASE" => "Lab database",
+        "SELECT_LAB" => "Select a lab",
+        "SQL_MIGRATION" => "SQL migration",
+        "SELECT_MIGRATION" => "Select a migration",
+        "APPLY" => "Apply"
+    )
 );
 
 include_once(__DIR__."/../lang/lang_util.php");

--- a/local/langdata_127/en.xml
+++ b/local/langdata_127/en.xml
@@ -2961,4 +2961,70 @@
             <value>Update Profile</value>
         </term>
     </page>
+    <page id="debug" descr="Debug Utilities">
+        <term>
+            <key>DEBUG_UTILITIES</key>
+            <value>Debug Utilities</value>
+        </term>
+        <term>
+            <key>GIT_COMMIT_SHA</key>
+            <value>Git commit SHA</value>
+        </term>
+        <term>
+            <key>BROWSE_SOURCE_CODE</key>
+            <value>browse source code</value>
+        </term>
+        <term>
+            <key>AVAILABLE_LOG_FILES</key>
+            <value>Available Log Files</value>
+        </term>
+        <term>
+            <key>LANGUAGE_UTILITIES</key>
+            <value>Language Utilities</value>
+        </term>
+        <term>
+            <key>RESET_UPDATE_LANGUAGE_FILES</key>
+            <value>Reset/update language files</value>
+        </term>
+        <term>
+            <key>DATABASE_UTILITIES</key>
+            <value>Database Utilities</value>
+        </term>
+        <term>
+            <key>LEGACY_LAB_DATABASE_MIGRATIONS</key>
+            <value>Legacy Lab Database Migrations</value>
+        </term>
+        <term>
+            <key>WARNING</key>
+            <value>Warning!</value>
+        </term>
+        <term>
+            <key>MIGRATION_WARNING</key>
+            <value>Running ANY of these migrations could break your lab configuration PERMANENTLY!</value>
+        </term>
+        <term>
+            <key>MIGRATION_DESCRIPTION</key>
+            <value>These migrations are used to perform manual updates to an imported lab configuration from an older version of BLIS.</value>
+        </term>
+        <term>
+            <key>LAB_DATABASE</key>
+            <value>Lab database</value>
+        </term>
+        <term>
+            <key>SELECT_LAB</key>
+            <value>Select a lab</value>
+        </term>
+        <term>
+            <key>SQL_MIGRATION</key>
+            <value>SQL migration</value>
+        </term>
+        <term>
+            <key>SELECT_MIGRATION</key>
+            <value>Select a migration</value>
+        </term>
+        <term>
+            <key>APPLY</key>
+            <value>Apply</value>
+        </term>
+    </page>
 </pages>

--- a/local/langdata_127/fr.php
+++ b/local/langdata_127/fr.php
@@ -722,7 +722,25 @@ $LANG_ARRAY = array (
 		"SEARCH_BEGIN_WITH" => "Commence par", 
 		"SEARCH_END_WITH" => "Fin d'", 
 		"SEARCH_CONTAINS" => "Contient"
-	) 
+	),
+	"debug" => array (
+        "DEBUG_UTILITIES" => "Utilitaires de débogage",
+        "GIT_COMMIT_SHA" => "SHA du commit Git",
+        "BROWSE_SOURCE_CODE" => "parcourir le code source",
+        "AVAILABLE_LOG_FILES" => "Fichiers de journal disponibles",
+        "LANGUAGE_UTILITIES" => "Utilitaires de langue",
+        "RESET_UPDATE_LANGUAGE_FILES" => "Réinitialiser/mettre à jour les fichiers de langue",
+        "DATABASE_UTILITIES" => "Utilitaires de base de données",
+        "LEGACY_LAB_DATABASE_MIGRATIONS" => "Migrations de la base de données du laboratoire hérité",
+        "WARNING" => "Attention!",
+        "MIGRATION_WARNING" => "Exécuter l'une de ces migrations pourrait casser votre configuration de laboratoire DE MANIÈRE PERMANENTE !",
+        "MIGRATION_DESCRIPTION" => "Ces migrations sont utilisées pour effectuer des mises à jour manuelles d'une configuration de laboratoire importée à partir d'une ancienne version de BLIS.",
+        "LAB_DATABASE" => "Base de données du laboratoire",
+        "SELECT_LAB" => "Sélectionnez un laboratoire",
+        "SQL_MIGRATION" => "Migration SQL",
+        "SELECT_MIGRATION" => "Sélectionnez une migration",
+        "APPLY" => "Appliquer"
+    )
 );
 
 include_once(__DIR__."/../lang/lang_util.php");

--- a/local/langdata_127/fr.xml
+++ b/local/langdata_127/fr.xml
@@ -2749,4 +2749,70 @@
 			<value>Contient</value>
 		</term>
  </page>
+ <page id="debug" descr="Debug Utilities">
+        <term>
+            <key>DEBUG_UTILITIES</key>
+            <value>Utilitaires de débogage</value>
+        </term>
+        <term>
+            <key>GIT_COMMIT_SHA</key>
+            <value>SHA du commit Git</value>
+        </term>
+        <term>
+            <key>BROWSE_SOURCE_CODE</key>
+            <value>parcourir le code source</value>
+        </term>
+        <term>
+            <key>AVAILABLE_LOG_FILES</key>
+            <value>Fichiers de journal disponibles</value>
+        </term>
+        <term>
+            <key>LANGUAGE_UTILITIES</key>
+            <value>Utilitaires de langue</value>
+        </term>
+        <term>
+            <key>RESET_UPDATE_LANGUAGE_FILES</key>
+            <value>Réinitialiser/mettre à jour les fichiers de langue</value>
+        </term>
+        <term>
+            <key>DATABASE_UTILITIES</key>
+            <value>Utilitaires de base de données</value>
+        </term>
+        <term>
+            <key>LEGACY_LAB_DATABASE_MIGRATIONS</key>
+            <value>Migrations de la base de données du laboratoire hérité</value>
+        </term>
+        <term>
+            <key>WARNING</key>
+            <value>Attention!</value>
+        </term>
+        <term>
+            <key>MIGRATION_WARNING</key>
+            <value>Exécuter l'une de ces migrations pourrait casser votre configuration de laboratoire DE MANIÈRE PERMANENTE !</value>
+        </term>
+        <term>
+            <key>MIGRATION_DESCRIPTION</key>
+            <value>Ces migrations sont utilisées pour effectuer des mises à jour manuelles d'une configuration de laboratoire importée à partir d'une ancienne version de BLIS.</value>
+        </term>
+        <term>
+            <key>LAB_DATABASE</key>
+            <value>Base de données du laboratoire</value>
+        </term>
+        <term>
+            <key>SELECT_LAB</key>
+            <value>Sélectionnez un laboratoire</value>
+        </term>
+        <term>
+            <key>SQL_MIGRATION</key>
+            <value>Migration SQL</value>
+        </term>
+        <term>
+            <key>SELECT_MIGRATION</key>
+            <value>Sélectionnez une migration</value>
+        </term>
+        <term>
+            <key>APPLY</key>
+            <value>Appliquer</value>
+        </term>
+    </page>
 </pages>

--- a/local/langdata_revamp/default.php
+++ b/local/langdata_revamp/default.php
@@ -777,7 +777,25 @@ $LANG_ARRAY = array (
 		"CMD_VIEWPROFILE" => "View Profile", 
 		"CMD_DELPROFILE" => "Delete Profile", 
 		"CMD_UPDPROFILE" => "Update Profile"
-	) 
+	) ,
+	"debug" => array (
+		"DEBUG_UTILITIES" => "Debug Utilities",
+		"GIT_COMMIT_SHA" => "Git commit SHA",
+		"BROWSE_SOURCE_CODE" => "browse source code",
+		"AVAILABLE_LOG_FILES" => "Available Log Files",
+		"LANGUAGE_UTILITIES" => "Language Utilities",
+		"RESET_UPDATE_LANGUAGE_FILES" => "Reset/update language files",
+		"DATABASE_UTILITIES" => "Database Utilities",
+		"LEGACY_LAB_DATABASE_MIGRATIONS" => "Legacy Lab Database Migrations",
+		"WARNING" => "Warning!",
+		"MIGRATION_WARNING" => "Running ANY of these migrations could break your lab configuration PERMANENTLY!",
+		"MIGRATION_DESCRIPTION" => "These migrations are used to perform manual updates to an imported lab configuration from an older version of BLIS.",
+		"LAB_DATABASE" => "Lab database",
+		"SELECT_LAB" => "Select a lab",
+		"SQL_MIGRATION" => "SQL migration",
+		"SELECT_MIGRATION" => "Select a migration",
+		"APPLY" => "Apply"
+	)
 );
 
 include_once(__DIR__."/../lang/lang_util.php");

--- a/local/langdata_revamp/default.xml
+++ b/local/langdata_revamp/default.xml
@@ -2961,4 +2961,70 @@
             <value>Update Profile</value>
         </term>
     </page>
+    <page id="debug" descr="Debug Utilities">
+        <term>
+            <key>DEBUG_UTILITIES</key>
+            <value>Debug Utilities</value>
+        </term>
+        <term>
+            <key>GIT_COMMIT_SHA</key>
+            <value>Git commit SHA</value>
+        </term>
+        <term>
+            <key>BROWSE_SOURCE_CODE</key>
+            <value>browse source code</value>
+        </term>
+        <term>
+            <key>AVAILABLE_LOG_FILES</key>
+            <value>Available Log Files</value>
+        </term>
+        <term>
+            <key>LANGUAGE_UTILITIES</key>
+            <value>Language Utilities</value>
+        </term>
+        <term>
+            <key>RESET_UPDATE_LANGUAGE_FILES</key>
+            <value>Reset/update language files</value>
+        </term>
+        <term>
+            <key>DATABASE_UTILITIES</key>
+            <value>Database Utilities</value>
+        </term>
+        <term>
+            <key>LEGACY_LAB_DATABASE_MIGRATIONS</key>
+            <value>Legacy Lab Database Migrations</value>
+        </term>
+        <term>
+            <key>WARNING</key>
+            <value>Warning!</value>
+        </term>
+        <term>
+            <key>MIGRATION_WARNING</key>
+            <value>Running ANY of these migrations could break your lab configuration PERMANENTLY!</value>
+        </term>
+        <term>
+            <key>MIGRATION_DESCRIPTION</key>
+            <value>These migrations are used to perform manual updates to an imported lab configuration from an older version of BLIS.</value>
+        </term>
+        <term>
+            <key>LAB_DATABASE</key>
+            <value>Lab database</value>
+        </term>
+        <term>
+            <key>SELECT_LAB</key>
+            <value>Select a lab</value>
+        </term>
+        <term>
+            <key>SQL_MIGRATION</key>
+            <value>SQL migration</value>
+        </term>
+        <term>
+            <key>SELECT_MIGRATION</key>
+            <value>Select a migration</value>
+        </term>
+        <term>
+            <key>APPLY</key>
+            <value>Apply</value>
+        </term>
+    </page>
 </pages>

--- a/local/langdata_revamp/en.php
+++ b/local/langdata_revamp/en.php
@@ -777,7 +777,25 @@ $LANG_ARRAY = array (
 		"CMD_VIEWPROFILE" => "View Profile", 
 		"CMD_DELPROFILE" => "Delete Profile", 
 		"CMD_UPDPROFILE" => "Update Profile"
-	) 
+	),
+	"debug" => array (
+		"DEBUG_UTILITIES" => "Debug Utilities",
+		"GIT_COMMIT_SHA" => "Git commit SHA",
+		"BROWSE_SOURCE_CODE" => "browse source code",
+		"AVAILABLE_LOG_FILES" => "Available Log Files",
+		"LANGUAGE_UTILITIES" => "Language Utilities",
+		"RESET_UPDATE_LANGUAGE_FILES" => "Reset/update language files",
+		"DATABASE_UTILITIES" => "Database Utilities",
+		"LEGACY_LAB_DATABASE_MIGRATIONS" => "Legacy Lab Database Migrations",
+		"WARNING" => "Warning!",
+		"MIGRATION_WARNING" => "Running ANY of these migrations could break your lab configuration PERMANENTLY!",
+		"MIGRATION_DESCRIPTION" => "These migrations are used to perform manual updates to an imported lab configuration from an older version of BLIS.",
+		"LAB_DATABASE" => "Lab database",
+		"SELECT_LAB" => "Select a lab",
+		"SQL_MIGRATION" => "SQL migration",
+		"SELECT_MIGRATION" => "Select a migration",
+		"APPLY" => "Apply"
+	)
 );
 
 include_once(__DIR__."/../lang/lang_util.php");

--- a/local/langdata_revamp/en.xml
+++ b/local/langdata_revamp/en.xml
@@ -2961,4 +2961,62 @@
             <value>Update Profile</value>
         </term>
     </page>
+    <page id="debug" descr="Debug Utilities">
+        <term>
+            <key>DEBUG_UTILITIES</key>
+            <value>Debug Utilities</value>
+        </term>
+        <term>
+            <key>GIT_COMMIT_SHA</key>
+            <value>Git commit SHA</value>
+        </term>
+        <term>
+            <key>BROWSE_SOURCE_CODE</key>
+            <value>browse source code</value>
+        </term>
+        <term>
+            <key>AVAILABLE_LOG_FILES</key>
+            <value>Available Log Files</value>
+        </term>
+        <term>
+            <key>LANGUAGE_UTILITIES</key>
+            <value>Language Utilities</value>
+        </term>
+        <term>
+            <key>RESET_UPDATE_LANGUAGE_FILES</key>
+            <value>Reset/update language files</value>
+        </term>
+        <term>
+            <key>DATABASE_UTILITIES</key>
+            <value>Database Utilities</value>
+        </term>
+        <term>
+            <key>LEGACY_LAB_DATABASE_MIGRATIONS</key>
+            <value>Legacy Lab Database Migrations</value>
+        </term>
+        <term>
+            <key>WARNING</key>
+            <value>Warning!</value>
+        </term>
+        <term>
+            <key>MIGRATION_WARNING</key>
+            <value>Running ANY of these migrations could break your lab configuration PERMANENTLY!</value>
+        </term>
+        <term>
+            <key>MIGRATION_DESCRIPTION</key>
+            <value>These migrations are used to perform manual updates to an imported lab configuration from an older version of BLIS.</value>
+        </term>
+        <term>
+            <key>LAB_DATABASE</key>
+            <value>Lab database</value>
+        </term>
+        <term>
+            <key>SELECT_LAB</key>
+            <value>Select a lab</value>
+        </term>
+        <term>
+            <key>SQL_MIGRATION</key>
+            <value>SQL migration</value>
+        </term>
+    </page>
 </pages>

--- a/local/langdata_revamp/fr.php
+++ b/local/langdata_revamp/fr.php
@@ -722,7 +722,25 @@ $LANG_ARRAY = array (
 		"SEARCH_BEGIN_WITH" => "Commence par", 
 		"SEARCH_END_WITH" => "Fin d'", 
 		"SEARCH_CONTAINS" => "Contient"
-	) 
+	) ,
+	"debug" => array (
+        "DEBUG_UTILITIES" => "Utilitaires de débogage",
+        "GIT_COMMIT_SHA" => "SHA du commit Git",
+        "BROWSE_SOURCE_CODE" => "parcourir le code source",
+        "AVAILABLE_LOG_FILES" => "Fichiers de journal disponibles",
+        "LANGUAGE_UTILITIES" => "Utilitaires de langue",
+        "RESET_UPDATE_LANGUAGE_FILES" => "Réinitialiser/mettre à jour les fichiers de langue",
+        "DATABASE_UTILITIES" => "Utilitaires de base de données",
+        "LEGACY_LAB_DATABASE_MIGRATIONS" => "Migrations de la base de données du laboratoire hérité",
+        "WARNING" => "Attention!",
+        "MIGRATION_WARNING" => "Exécuter l'une de ces migrations pourrait casser votre configuration de laboratoire DE MANIÈRE PERMANENTE !",
+        "MIGRATION_DESCRIPTION" => "Ces migrations sont utilisées pour effectuer des mises à jour manuelles d'une configuration de laboratoire importée à partir d'une ancienne version de BLIS.",
+        "LAB_DATABASE" => "Base de données du laboratoire",
+        "SELECT_LAB" => "Sélectionnez un laboratoire",
+        "SQL_MIGRATION" => "Migration SQL",
+        "SELECT_MIGRATION" => "Sélectionnez une migration",
+        "APPLY" => "Appliquer"
+    )
 );
 
 include_once(__DIR__."/../lang/lang_util.php");

--- a/local/langdata_revamp/fr.xml
+++ b/local/langdata_revamp/fr.xml
@@ -2749,4 +2749,70 @@
 			<value>Contient</value>
 		</term>
  </page>
+ <page id="debug" descr="Debug Page">
+    <term>
+        <key>DEBUG_UTILITIES</key>
+        <value>Utilitaires de débogage</value>
+    </term>
+    <term>
+        <key>GIT_COMMIT_SHA</key>
+        <value>SHA du commit Git</value>
+    </term>
+    <term>
+        <key>BROWSE_SOURCE_CODE</key>
+        <value>parcourir le code source</value>
+    </term>
+    <term>
+        <key>AVAILABLE_LOG_FILES</key>
+        <value>Fichiers de journal disponibles</value>
+    </term>
+    <term>
+        <key>LANGUAGE_UTILITIES</key>
+        <value>Utilitaires de langue</value>
+    </term>
+    <term>
+        <key>RESET_UPDATE_LANGUAGE_FILES</key>
+        <value>Réinitialiser/mettre à jour les fichiers de langue</value>
+    </term>
+    <term>
+        <key>DATABASE_UTILITIES</key>
+        <value>Utilitaires de base de données</value>
+    </term>
+    <term>
+        <key>LEGACY_LAB_DATABASE_MIGRATIONS</key>
+        <value>Migrations de la base de données du laboratoire hérité</value>
+    </term>
+    <term>
+        <key>WARNING</key>
+        <value>Attention!</value>
+    </term>
+    <term>
+        <key>MIGRATION_WARNING</key>
+        <value>Exécuter l'une de ces migrations pourrait casser votre configuration de laboratoire DE MANIÈRE PERMANENTE !</value>
+    </term>
+    <term>
+        <key>MIGRATION_DESCRIPTION</key>
+        <value>Ces migrations sont utilisées pour effectuer des mises à jour manuelles d'une configuration de laboratoire importée à partir d'une ancienne version de BLIS.</value>
+    </term>
+    <term>
+        <key>LAB_DATABASE</key>
+        <value>Base de données du laboratoire</value>
+    </term>
+    <term>
+        <key>SELECT_LAB</key>
+        <value>Sélectionnez un laboratoire</value>
+    </term>
+    <term>
+        <key>SQL_MIGRATION</key>
+        <value>Migration SQL</value>
+    </term>
+    <term>
+        <key>SELECT_MIGRATION</key>
+        <value>Sélectionnez une migration</value>
+    </term>
+    <term>
+        <key>APPLY</key>
+        <value>Appliquer</value>
+    </term>
+</page>
 </pages>


### PR DESCRIPTION
Localizing the strings displayed on the Debug Tools page (debug.php).

Added a new section in the respective language *.php and *.xml files to include the strings for the Debug Tools page.

Google translate was utilized for helping with the french translations.