### PR TITLE
Add LabConfigResolver class to unify the logic around finding the current lab_config_id

### DIFF
--- a/htdocs/config/lab_config_resolver.php
+++ b/htdocs/config/lab_config_resolver.php
@@ -1,0 +1,54 @@
+<?php
+
+require_once(__DIR__."/../includes/composer.php");
+require_once(__DIR__."/../includes/db_lib.php");
+
+/**
+ * This class exists to answer one question: What lab_config_id should I use right now?
+ * This is an annoying problem that is solved in many ways around the codebase...
+ * Now we can cram all of the logic we need in one place, and hopefully introduce some caching too.
+ */
+class LabConfigResolver {
+
+    private static $resolved_lab_config_id = null;
+
+    public static function resolveId() {
+        global $log;
+
+        if (LabConfigResolver::$resolved_lab_config_id != null) {
+            $log->debug("lab_config_id was cached");
+            return LabConfigResolver::$resolved_lab_config_id;
+        }
+
+        if(isset($_SESSION["lab_config_id"]) && $_SESSION["lab_config_id"] != null) {
+            LabConfigResolver::$resolved_lab_config_id = $_SESSION["lab_config_id"];
+            $log->debug("Resolved lab_config_id: ". LabConfigResolver::$resolved_lab_config_id ." from session.");
+            return LabConfigResolver::$resolved_lab_config_id;
+        }
+
+        if (isset($_SESSION["user_id"]) && $_SESSION["user_id"] != null) {
+            LabConfigResolver::$resolved_lab_config_id = get_user_lab_id($_SESSION["user_id"]);
+
+            if (LabConfigResolver::$resolved_lab_config_id > 0) {
+                $log->debug("Resolved lab_config_id: ". LabConfigResolver::$resolved_lab_config_id ." from logged in user_id: " . $_SESSION["user_id"]);
+                return LabConfigResolver::$resolved_lab_config_id;
+            }
+
+            if(User::onlyOneLabConfig($_SESSION['user_id'], $_SESSION['user_level'])) {
+                $lab_config_list = get_lab_configs($_SESSION['user_id']);
+                LabConfigResolver::$resolved_lab_config_id = $lab_config_list[0]->id;
+                $log->debug("Resolved lab_config_id: ". LabConfigResolver::$resolved_lab_config_id ." by looking up labs that user ID : " . $_SESSION["user_id"] . " has access to.");
+                return LabConfigResolver::$resolved_lab_config_id;
+            }
+
+            $lab_config_with_admin_uid = get_first_lab_config_with_admin_user_id($_SESSION['user_id']);
+            if ($lab_config_with_admin_uid) {
+                LabConfigResolver::$resolved_lab_config_id = $lab_config_with_admin_uid;
+                $log->debug("Resolved lab_config_id: ". LabConfigResolver::$resolved_lab_config_id ." by looking up labs with admin user ID : " . $_SESSION["user_id"]);
+                return LabConfigResolver::$resolved_lab_config_id;
+            }
+        }
+
+        $log->warn("Could not resolve lab_config_id. Logged in user ID: " . $_SESSION["user_id"]);
+    }
+}

--- a/htdocs/includes/db_lib.php
+++ b/htdocs/includes/db_lib.php
@@ -7104,14 +7104,14 @@ function get_satellite_lab_user_id($user_id)
 	# Retrievest the satellite_lab_id associated for the logged user
     global $con;
     $user_id = mysql_real_escape_string($user_id, $con);
- 
+
     $saved_db = DbUtil::switchToGlobal();
     $query_string = "SELECT satellite_lab_id FROM user WHERE user_id = $user_id";
     $record = query_associative_one($query_string);
     DbUtil::switchRestore($saved_db);
     return $record["satellite_lab_id"];
 }
- 
+
 function search_specimens_by_id($q)
 {
 	global $con;
@@ -16612,6 +16612,15 @@ VALUES (NULL , '$this->username', '$this->password', '$this->orgUnit', '$this->d
         $saved_db = DbUtil::switchToGlobal();
         $uid = db_escape($user_id);
         $query = "SELECT lab_config_id FROM user WHERE user_id = '$uid';";
+        $res = query_associative_one($query);
+        DbUtil::switchRestore($saved_db);
+        return $res['lab_config_id'];
+    }
+
+    function get_first_lab_config_with_admin_user_id($user_id) {
+        $saved_db = DbUtil::switchToGlobal();
+        $uid = db_escape($user_id);
+        $query = "SELECT lab_config_id FROM lab_config WHERE admin_user_id = '$uid' LIMIT 1;";
         $res = query_associative_one($query);
         DbUtil::switchRestore($saved_db);
         return $res['lab_config_id'];

--- a/htdocs/includes/header.php
+++ b/htdocs/includes/header.php
@@ -9,14 +9,12 @@ set_include_path(get_include_path() . PATH_SEPARATOR . $path);
 require_once(__DIR__."/SessionCheck.php");
 require_once(__DIR__."/db_lib.php");
 require_once(__DIR__."/features.php");
+require_once(__DIR__."/../config/lab_config_resolver.php");
 
 # Session hack for pages that use the header
 # Make sure $_SESSION["lab_config_id"] is set... something really hates the session
 # and is constantly overwriting lab_config_id. Can't figure out where.
-if ($_SESSION["lab_config_id"] == null && $_SESSION["user_id"] != null) {
-    $lcid = get_user_lab_id($_SESSION["user_id"]);
-    $_SESSION["lab_config_id"] = $lcid;
-}
+$_SESSION["lab_config_id"] = LabConfigResolver::resolveId();
 
 $TRACK_LOADTIME = false;
 $TRACK_LOADTIMEJS = false;

--- a/htdocs/regn/find_patient.php
+++ b/htdocs/regn/find_patient.php
@@ -6,16 +6,16 @@
 #
 include("redirect.php");
 include("includes/header.php");
+require_once(__DIR__."/../config/lab_config_resolver.php");
 LangUtil::setPageId("find_patient");
 
 putUILog('find_patient', 'X', basename($_SERVER['REQUEST_URI'], ".php"), 'X', 'X', 'X');
 
-
-
 $script_elems->enableDatePicker();
 $script_elems->enableJQueryForm();
 
-$lab_config = get_lab_config_by_id($_SESSION['lab_config_id']);
+$lab_config_id = LabConfigResolver::resolveId();
+$lab_config = get_lab_config_by_id($lab_config_id);
 ?>
 <script type='text/javascript'>
 $(document).ready(function() {
@@ -28,7 +28,7 @@ $(document).ready(function() {
 });
 
 function restrictCharacters(e) {
-	
+
 	var alphabets = /[A-Za-z]/g;
 	var numbers = /[0-9]/g;
 	var specialCharacter = /[_&.]/g;
@@ -36,7 +36,7 @@ function restrictCharacters(e) {
 	if( e.keyCode ) code = e.keyCode;
 	else if ( e.which) code = e.which;
 	var character = String.fromCharCode(code);
-	
+
 	if( !e.ctrlKey && code!=9 && code!=8 && code!=27 && code!=36 && code!=37 && code!=38  && code!=40 &&code!=13 &&code!=32 ) {
 		if ( !character.match(alphabets) && !character.match(numbers) && !character.match(specialCharacter))
 			return false;
@@ -71,7 +71,7 @@ function fetch_patients()
 
 function delete_patient_profile(patientId){
 	if(ConfirmDelete()){
-	var params = "patient_id="+patientId+"&lab_config_id="+<?php echo $lab_config->id;?>;
+	var params = "patient_id="+patientId+"&lab_config_id="+<?php echo($lab_config->id); ?>;
 	//alert("patient Id " + patient_id);
 	$.ajax({
 		type: "POST",
@@ -87,7 +87,7 @@ function delete_patient_profile(patientId){
 			$("#patients_found").html('');
 			$("#add_anyway_div").hide();
 		}
-	}); 
+	});
 }
 }
 
@@ -115,8 +115,8 @@ function continue_fetch_patients()
 		return;
 	}
 	var url = 'ajax/search_p.php';
-	$("#patients_found").load(url, 
-		{q: patient_id, a: search_attrib, c: condition_attrib}, 
+	$("#patients_found").load(url,
+		{q: patient_id, a: search_attrib, c: condition_attrib},
 		function(response)
 		{
 			$('#psearch_progress_spinner').hide();
@@ -153,8 +153,8 @@ function hideCondition(p_attrib)
 		if(LangUtil::$pageTerms['TIPS_REGISTRATION_1']!="-") {
 			echo "This page allows us to register new patients or lookup existing patients based on name, patient ID or number.";
 			echo "</br>";
-		}	
-		
+		}
+
 		?>
 </div>
 
@@ -166,7 +166,7 @@ function hideCondition(p_attrib)
 		<?php $page_elems->getPatientSearchAttribSelect(); ?>
 	</select><select name='h_attrib' id='h_attrib' style='font-family:Tahoma;'>
 		<?php $page_elems->getPatientSearchCondition(); ?>
-        
+
 	</select>
 	&nbsp;&nbsp;
 	<input type='text' name='pq' id='pq' style='font-family:Tahoma;' onkeypress="return restrictCharacters(event)" />
@@ -185,16 +185,16 @@ function hideCondition(p_attrib)
 			echo "<li>";
 			echo LangUtil::$pageTerms['TIPS_REGISTRATION_1'];
 			echo "</li>";
-		}	
+		}
 		if(LangUtil::$pageTerms['TIPS_REGISTRATION_2']!="-") {
-			echo "<li>"; 
+			echo "<li>";
 			echo LangUtil::$pageTerms['TIPS_REGISTRATION_2'];
 			echo "</li>";
 		}
 		if(LangUtil::$pageTerms['TIPS_PATIENT_LOOKUP']!="-")	{
-			echo "<li>"; 
+			echo "<li>";
 			echo LangUtil::$pageTerms['TIPS_PATIENT_LOOKUP'];
-			echo "</li>"; 
+			echo "</li>";
 		}
 		?>
 	</ul>


### PR DESCRIPTION
The `find_patient.php` page is not loading properly for me, and it is because there is no value for `$_SESSION["lab_config_id"];`. There are other ways that BLIS resolves this when the session doesn't have it, but there's no "one true way." This PR introduces a class that provides "one true way" by combining a bunch of ways to resolve the lab config ID.