### PR TITLE
Add logging to query_insert_one and fix empty satellite lab ID in patient registration

### DIFF
--- a/htdocs/includes/db_lib.php
+++ b/htdocs/includes/db_lib.php
@@ -6461,8 +6461,14 @@ function add_patient($patient, $importOn = false)
 	$surr_id = db_escape($patient->surrogateId);
 	$created_by = db_escape($patient->createdBy);
 	$hash_value = $patient->generateHashValue();
-	$satellite_lab_id = db_escape($patient->satelliteLabId);
-	$satellite_lab_name = db_escape($patient->satelliteLabName);
+
+    if ($patient->satelliteLabId != NULL && $patient->satelliteLabId != "") {
+        $satellite_lab_id = db_escape($patient->satelliteLabId);
+        $satellite_lab_name = db_escape($patient->satelliteLabName);
+
+        $satelliteLabKeys = ", `satellite_lab_id`, `satellite_lab_name`";
+        $satelliteLabValues = ", $satellite_lab_id, '$satellite_lab_name'";
+    }
 
 	$query_string = "";
 
@@ -6476,20 +6482,20 @@ function add_patient($patient, $importOn = false)
 	if($dob == "" && $partial_dob == "")
 	{
 		$query_string =
-			"INSERT INTO `patient`(`patient_id`, `addl_id`, `name`, `age`, `sex`, `surr_id`, `created_by`, `hash_value` ,`ts`, `satellite_lab_id`, `satellite_lab_name`) ".
-			"VALUES ($pid, '$addl_id', '$name', $age, '$sex', '$surr_id', $created_by, '$hash_value', '$receipt_date', '$satellite_lab_id', '$satellite_lab_name')";
+			"INSERT INTO `patient`(`patient_id`, `addl_id`, `name`, `age`, `sex`, `surr_id`, `created_by`, `hash_value` ,`ts` $satelliteLabKeys) ".
+			"VALUES ($pid, '$addl_id', '$name', $age, '$sex', '$surr_id', $created_by, '$hash_value', '$receipt_date' $satelliteLabValues)";
 	}
 	else if($partial_dob != "")
 	{
 		$query_string =
-			"INSERT INTO `patient`(`patient_id`, `addl_id`, `name`, `age`, `sex`, `partial_dob`, `surr_id`, `created_by`, `hash_value`,`ts`, `satellite_lab_id`, `satellite_lab_name`) ".
-			"VALUES ($pid, '$addl_id', '$name', $age, '$sex', '$partial_dob', '$surr_id', $created_by, '$hash_value', '$receipt_date', '$satellite_lab_id', '$satellite_lab_name')";
+			"INSERT INTO `patient`(`patient_id`, `addl_id`, `name`, `age`, `sex`, `partial_dob`, `surr_id`, `created_by`, `hash_value`,`ts` $satelliteLabKeys) ".
+			"VALUES ($pid, '$addl_id', '$name', $age, '$sex', '$partial_dob', '$surr_id', $created_by, '$hash_value', '$receipt_date' $satelliteLabValues)";
 	}
 	else
 	{
 		$query_string =
-			"INSERT INTO `patient`(`patient_id`, `addl_id`, `name`, `dob`, `age`, `sex`, `surr_id`, `created_by`, `hash_value`, `ts`, `satellite_lab_id`, `satellite_lab_name`) ".
-			"VALUES ($pid, '$addl_id', '$name', '$dob', $age, '$sex', '$surr_id', $created_by, '$hash_value', '$receipt_date', $satellite_lab_id', '$satellite_lab_name')";
+			"INSERT INTO `patient`(`patient_id`, `addl_id`, `name`, `dob`, `age`, `sex`, `surr_id`, `created_by`, `hash_value`, `ts` $satelliteLabKeys) ".
+			"VALUES ($pid, '$addl_id', '$name', '$dob', $age, '$sex', '$surr_id', $created_by, '$hash_value', '$receipt_date' $satelliteLabValues)";
 	}
 
 	print $query_string;

--- a/htdocs/includes/db_mysql_lib.php
+++ b/htdocs/includes/db_mysql_lib.php
@@ -27,8 +27,15 @@ function _db_get_username() {
 function query_insert_one($query)
 {
 	# Single insert statement
-	global $con, $LOG_QUERIES;
-    mysqli_query($con,  $query ) or die(mysqli_error($con));
+	global $con, $LOG_QUERIES, $log;
+    $result = mysqli_query($con, $query);
+
+    if (!$result) {
+        $err = mysqli_error($con);
+        $log->error("mysqli error: " . $err);
+        die();
+    }
+
 	if($LOG_QUERIES == true) {
         DebugLib::logDBUpdates($query, db_get_current());
         DebugLib::logQuery($query, db_get_current(), _db_get_username());


### PR DESCRIPTION
cc @asuquoe62-star @Tjones1701 

Dug into this one to see if I could see what was wrong.

## Debugging

In order to diagnose this, I first opened Network Tools in Firefox/Chrome and tried to register a patient. I noticed the file `patient_add.php` was called with POST, but it never returned. So, I added `$log->warning()` statements to the file in various places to find where it was dying. I saw it was dying in the `add_patient()` function, which is located in `db_lib.php`.

I did the same thing in that function. When I saw the MySQL query didn't work, I changed the function to log the error. That yielded this error in `application.log`: `mysqli error: Incorrect integer value: '' for column 'satellite_lab_id' at row 1`.

This means an empty string was being passed in to `satellite_lab_id` but the column type was not string. Since the column is nullable, that means we can just stop passing that value at all if it is null.