### PR TITLE
Update old-structured release build

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     
     steps:
       - name: Checkout BLIS
@@ -61,25 +61,24 @@ jobs:
 
       - name: Prepare Artifact Folders
         run: |
-          mkdir BLIS-Standalone
+          mkdir -p BLIS-Standalone
           
           # Copy BLISRuntime (excluding .git)
-          Copy-Item "./BLISRuntime/*" -Destination "./BLIS-Standalone/" -Recurse -Exclude ".git"
+          cp -r BLISRuntime/. BLIS-Standalone/ && rm -rf BLIS-Standalone/.git
           
           # Copy BLIS (excluding .git and the legacy EXEs)
-          Copy-Item "./BLIS/*" -Destination "./BLIS-Standalone/" -Recurse -Exclude ".git"
-          Remove-Item "./BLIS-Standalone/BLIS.exe" -ErrorAction SilentlyContinue
-          Remove-Item "./BLIS-Standalone/BLIS.exe.manifest" -ErrorAction SilentlyContinue
+          cp -r BLIS/. BLIS-Standalone/ && rm -rf BLIS-Standalone/.git
+          rm -f BLIS-Standalone/BLIS.exe BLIS-Standalone/BLIS.exe.manifest
           
           # Copy BLIS-NG executable
-          Copy-Item "./BLIS-NG/bin/Release/net10.0/win-x64/publish/BLIS-NG.exe" -Destination "./BLIS-Standalone/"
+          cp BLIS-NG/bin/Release/net10.0/win-x64/publish/BLIS-NG.exe BLIS-Standalone/
 
       - name: Create Zip Archive
         run: |
-          Compress-Archive -Path "BLIS-Standalone/*" -DestinationPath BLIS-Standalone.zip
+          cd BLIS-Standalone && zip -r ../BLIS-Standalone.zip . && cd ..
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: BLIS-Standalone
           path: BLIS-Standalone.zip

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -73,12 +73,27 @@ jobs:
           # Copy BLIS-NG executable
           cp BLIS-NG/bin/Release/net10.0/win-x64/publish/BLIS-NG.exe BLIS-Standalone/
 
-      - name: Create Zip Archive
+          mkdir -p BLIS-Upgrade
+
+          # Copy BLIS (excluding .git and local/ runtime data)
+          cp -r BLIS/. BLIS-Upgrade/ && rm -rf BLIS-Upgrade/.git BLIS-Upgrade/local
+
+          # Copy BLISRuntime server component
+          cp -r BLISRuntime/server BLIS-Upgrade/server
+
+      - name: Create Zip Archives
         run: |
           cd BLIS-Standalone && zip -r ../BLIS-Standalone.zip . && cd ..
+          cd BLIS-Upgrade && zip -r ../BLIS-Upgrade.zip . && cd ..
 
-      - name: Upload Artifact
+      - name: Upload Standalone Artifact
         uses: actions/upload-artifact@v4
         with:
           name: BLIS-Standalone
           path: BLIS-Standalone.zip
+
+      - name: Upload Upgrade Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: BLIS-Upgrade
+          path: BLIS-Upgrade.zip

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -81,19 +81,14 @@ jobs:
           # Copy BLISRuntime server component
           cp -r BLISRuntime/server BLIS-Upgrade/server
 
-      - name: Create Zip Archives
-        run: |
-          cd BLIS-Standalone && zip -r ../BLIS-Standalone.zip . && cd ..
-          cd BLIS-Upgrade && zip -r ../BLIS-Upgrade.zip . && cd ..
-
       - name: Upload Standalone Artifact
         uses: actions/upload-artifact@v4
         with:
           name: BLIS-Standalone
-          path: BLIS-Standalone.zip
+          path: BLIS-Standalone/
 
       - name: Upload Upgrade Artifact
         uses: actions/upload-artifact@v4
         with:
           name: BLIS-Upgrade
-          path: BLIS-Upgrade.zip
+          path: BLIS-Upgrade/


### PR DESCRIPTION
**This does not include the new directory structure to support self-update**

This PR enhances the existing build-release workflow to also build an upgrade archive. Both the standalone and upgrade archives have the old directory structure.

Changes: 
1. Migrates workflow file to bash instead of powershell. There will be no Windows specific steps in this workflow. Windows runners are more expensive. 
2. Builds a BLIS-Upgrade archive. 
3. Removes the zip within a zip issue. 