### PR TITLE
Use AES-256-CBC for cloud backup exchange

### DIFF
--- a/htdocs/config/v2/blis_cloud_server.php
+++ b/htdocs/config/v2/blis_cloud_server.php
@@ -101,6 +101,7 @@ if ($action == "connect") {
 
     $backup_date = $_POST["backup_date"];
     $backup_envelope_key = $_POST["envelope_key"];
+    $backup_iv = $_POST["iv"];
     $backup_filename = $_FILES["backup_file"]["name"];
     $backup_tmp_path = $_FILES["backup_file"]["tmp_name"];
 
@@ -111,7 +112,7 @@ if ($action == "connect") {
     $decrypted_path = "$backup_location/$backup_filename";
 
     $enc = new EncryptedFile($backup_tmp_path);
-    $result = $enc->decrypt("LAB_dir.blis", $backup_envelope_key, $decrypted_path);
+    $result = $enc->decrypt("LAB_dir.blis", $backup_envelope_key, $backup_iv, $decrypted_path);
 
     if (!$result) {
         header(LangUtil::$generalTerms['500_SERVER_ERROR'], true, 500);

--- a/htdocs/config/v2/lib/encrypted_file.php
+++ b/htdocs/config/v2/lib/encrypted_file.php
@@ -8,15 +8,19 @@ class EncryptedFile {
     private $filename;
     private $cipher_algo;
 
-    function __construct($filename, $cipher_algo="RC4") {
+    function __construct($filename, $cipher_algo="aes-256-cbc") {
         $this->filename = $filename;
         $this->cipher_algo = $cipher_algo;
     }
 
-    public function decrypt($decryption_pvt_key, $b64_decryption_envelope_key, $destination_filename) {
+    public function decrypt($decryption_pvt_key, $b64_decryption_envelope_key, $b64_iv, $destination_filename) {
         global $log;
 
         $decryption_envelope_key = base64_decode($b64_decryption_envelope_key);
+        $decryption_iv = null;
+        if ($b64_iv != "") {
+            $decryption_iv = base64_decode($b64_iv);
+        }
 
         $keypath = KeyMgmt::pathToKey($decryption_pvt_key);
         $pvt_key = openssl_get_privatekey("file://$keypath");
@@ -28,7 +32,7 @@ class EncryptedFile {
         $encrypted_blob = file_get_contents($this->filename);
         $decrypted_blob = null;
 
-        if (openssl_open($encrypted_blob, $decrypted_blob, $decryption_envelope_key, $pvt_key, $this->cipher_algo)) {
+        if (openssl_open($encrypted_blob, $decrypted_blob, $decryption_envelope_key, $pvt_key, $this->cipher_algo, $decryption_iv)) {
             $log->info("Decryption of ".$destination_filename . " succeeded!");
             file_put_contents($destination_filename, $decrypted_blob);
             return true;

--- a/htdocs/config/v2/send_cloud_backup.php
+++ b/htdocs/config/v2/send_cloud_backup.php
@@ -66,10 +66,14 @@ $backup_blob = file_get_contents($latest_backup->full_path);
 
 $log->info("Sending backup: " . $latest_backup->full_path . " to " . $connect_url);
 
-// WARNING! RC4 is a very outdated and insecure encryption algorithm.
-// This will prevent only the most simple attempts to decrypt the file.
-// Unfortunately, the old version of PHP we use on Windows prevents anything newer (for now...)
-$ossl_result = openssl_seal($backup_blob, $sealed_data, $ekeys, array($ossl_pubkey), "RC4");
+// AES256 is probably not the best choice of encryption algorithm.
+// This should be dynamic, or more centrally managed somewhere.
+$cipher_algo = "aes-256-cbc";
+$iv_required = openssl_cipher_iv_length($cipher_algo) != false;
+$iv = null;
+$iv_b64 = '';
+
+$ossl_result = openssl_seal($backup_blob, $sealed_data, $ekeys, array($ossl_pubkey), "aes-256-cbc", $iv);
 if ($ossl_result === false) {
     $log->error("Could not encrypt backup: " . openssl_error_string());
     $_SESSION["FLASH"] = "Error sending backup.";
@@ -83,6 +87,9 @@ file_put_contents($encpath, $sealed_data);
 $log->info("Backup " . $latest_backup->full_path . " encrypted successfully.");
 
 $ekey = base64_encode($ekeys[0]);
+if ($iv_required) {
+    $iv_b64 = base64_encode($iv);
+}
 
 $curlfile = '@' . realpath($encpath);
 
@@ -91,7 +98,8 @@ $post = array(
     'connection_code'=>$connect_code,
     'backup_file'=>$curlfile,
     'backup_date'=>$latest_backup->timestamp,
-    'envelope_key'=>$ekey
+    'envelope_key'=>$ekey,
+    'iv'=>$iv_b64,
 );
 
 $log->info("Sending backup to BLIS cloud with URL: ".$connect_url);

--- a/htdocs/encryption/encryption.php
+++ b/htdocs/encryption/encryption.php
@@ -32,6 +32,8 @@ class Encryption
 
     public static function decrypt($input, $keycontents)
     {
+        global $log;
+
         $keypair = base64_decode($keycontents);
         $res = false;
         try {
@@ -53,6 +55,7 @@ class Encryption
     public static function decryptFile($inputFile, $outputFile, $keycontents)
     {
         global $log;
+
         $data = file_get_contents($inputFile);
         try {
             $res = Encryption::decrypt($data, $keycontents);


### PR DESCRIPTION
The currently used cipher algorithm for exchanging backups is RC4, which is long-deprecated. Since we're using a more-recent version of PHP now we can use a more recent cipher algorithm (although this one probably also has its own issues.)