### PR TITLE
Avoid using Git LFS when building release

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -33,7 +33,7 @@ jobs:
           
       - name: Download BLISRuntime
         run: |
-          curl -fsSlo blisruntime.zip "https://github.com/C4G/BLISRuntime/releases/download/{{inputs.blisruntime_branch}}/BLISRuntime.zip"
+          Invoke-WebRequest -OutFile blisruntime.zip -Uri "https://github.com/C4G/BLISRuntime/releases/download/${{inputs.blisruntime_branch}}/BLISRuntime.zip"
           unzip blisruntime.zip
           
       - name: Checkout BLIS-NG

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -9,9 +9,9 @@ on:
         default: 'main'
         type: string
       blisruntime_branch:
-        description: 'Branch for C4G/BLISRuntime'
+        description: 'Release version of C4G/BLISRuntime'
         required: true
-        default: 'main'
+        default: 'v4.0.0'
         type: string
       blisng_branch:
         description: 'Branch for C4G/BLIS-NG'
@@ -31,15 +31,10 @@ jobs:
           ref: ${{ inputs.blis_branch }}
           path: 'BLIS'
           
-      - name: Checkout BLISRuntime
-        uses: actions/checkout@v7
-        with:
-          repository: 'C4G/BLISRuntime'
-          # BLISRuntime contains large binary files using Git LFS
-          # https://git-lfs.com/
-          lfs: true
-          ref: ${{ inputs.blisruntime_branch }}
-          path: 'BLISRuntime'
+      - name: Download BLISRuntime
+        run: |
+          curl -fsSlo blisruntime.zip "https://github.com/C4G/BLISRuntime/releases/download/{{inputs.blisruntime_branch}}/BLISRuntime.zip"
+          unzip blisruntime.zip
           
       - name: Checkout BLIS-NG
         uses: actions/checkout@v7

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -34,7 +34,8 @@ jobs:
       - name: Download BLISRuntime
         run: |
           Invoke-WebRequest -OutFile blisruntime.zip -Uri "https://github.com/C4G/BLISRuntime/releases/download/${{inputs.blisruntime_branch}}/BLISRuntime.zip"
-          unzip blisruntime.zip
+          mkdir BLISRuntime
+          Expand-Archive -Path blisruntime.zip -DestinationPath BLISRuntime/
           
       - name: Checkout BLIS-NG
         uses: actions/checkout@v7


### PR DESCRIPTION
Git LFS is not free for how much this Action uses it, and we don't need to be using it every time anyway. Download BLISRuntime from releases instead now.